### PR TITLE
feat: Brave support + Phase 4 Reddit platform adapter

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -46,6 +46,16 @@
       "js": ["core/classifier.js", "platforms/youtube.js"],
       "css": ["styles.css"],
       "run_at": "document_idle"
+    },
+    {
+      "matches": [
+        "https://www.reddit.com/*",
+        "https://old.reddit.com/*",
+        "https://reddit.com/*"
+      ],
+      "js": ["core/classifier.js", "platforms/reddit.js"],
+      "css": ["styles.css"],
+      "run_at": "document_idle"
     }
   ]
 }

--- a/extension/platforms/reddit.js
+++ b/extension/platforms/reddit.js
@@ -1,0 +1,253 @@
+/**
+ * IntentKeeper - Reddit Platform Adapter
+ *
+ * Handles three Reddit DOM variants:
+ *   - Shreddit (current new Reddit, ~2023+): <shreddit-post>, <shreddit-comment>
+ *   - Old new Reddit (pre-shreddit): div[data-testid="post-container"]
+ *   - Old Reddit (old.reddit.com): .thing.link, .thing.comment
+ *
+ * Intercepts:
+ *   - Post titles in feeds and listing pages
+ *   - Self-post (text post) body content
+ *   - Top-level comments
+ *
+ * All classification logic lives in core/classifier.js.
+ */
+
+// ---- Reddit variant detection ----
+
+function isOldReddit() {
+  return window.location.hostname === 'old.reddit.com';
+}
+
+function isShreddit() {
+  // Shreddit uses a custom <shreddit-app> root element
+  return document.querySelector('shreddit-app') !== null;
+}
+
+// ---- Text extraction: Shreddit ----
+
+function extractShredditPostText(element) {
+  const parts = [];
+
+  // Title lives in the [slot="title"] or as a direct attribute
+  const titleSlot = element.querySelector('[slot="title"]');
+  if (titleSlot) {
+    parts.push(titleSlot.textContent.trim());
+  } else {
+    // Fallback: read from the post-title attribute on the custom element
+    const attrTitle = element.getAttribute('post-title');
+    if (attrTitle) parts.push(attrTitle.trim());
+  }
+
+  // Subreddit context helps with tone calibration
+  const sub = element.getAttribute('subreddit-name') || element.getAttribute('subreddit-prefixed-name');
+  if (sub) parts.push(`[${sub}]`);
+
+  // Post flair can indicate community norms
+  const flair = element.querySelector('[slot="flair"]');
+  if (flair) {
+    const flairText = flair.textContent.trim();
+    if (flairText) parts.push(`[Flair: ${flairText}]`);
+  }
+
+  return parts.join(' | ');
+}
+
+function extractShredditCommentText(element) {
+  const parts = [];
+
+  const author = element.getAttribute('author');
+  if (author) parts.push(`[u/${author}]`);
+
+  // Comment body is in [slot="comment"]
+  const body = element.querySelector('[slot="comment"]');
+  if (body) {
+    const text = body.textContent.trim();
+    // Cap at 400 chars - comments can be essays; first 400 captures the tone
+    if (text) parts.push(text.slice(0, 400));
+  }
+
+  return parts.join(' | ');
+}
+
+// ---- Text extraction: Old new Reddit ----
+
+function extractNewRedditPostText(element) {
+  const parts = [];
+
+  const title = element.querySelector('h3, [data-click-id="text"] h3, h1');
+  if (title) parts.push(title.textContent.trim());
+
+  // Subreddit badge
+  const sub = element.querySelector('[data-click-id="subreddit"], h3[id^="post-title"] ~ *');
+  if (sub) {
+    const subText = sub.textContent.trim();
+    if (subText.startsWith('r/')) parts.push(`[${subText}]`);
+  }
+
+  // Post flair
+  const flair = element.querySelector('[class*="flair"]');
+  if (flair) {
+    const flairText = flair.textContent.trim();
+    if (flairText) parts.push(`[Flair: ${flairText}]`);
+  }
+
+  return parts.join(' | ');
+}
+
+function extractNewRedditCommentText(element) {
+  const parts = [];
+
+  const author = element.querySelector('[data-testid="comment_author_link"], a[href*="/user/"]');
+  if (author) parts.push(`[${author.textContent.trim()}]`);
+
+  // Comment body - RichTextJSON or plain paragraph
+  const body = element.querySelector('.RichTextJSON-root, [data-testid="comment"] > div p');
+  if (body) {
+    const text = body.textContent.trim();
+    if (text) parts.push(text.slice(0, 400));
+  }
+
+  return parts.join(' | ');
+}
+
+// ---- Text extraction: Old Reddit ----
+
+function extractOldRedditPostText(element) {
+  const parts = [];
+
+  const title = element.querySelector('.title > a.title, p.title > a');
+  if (title) parts.push(title.textContent.trim());
+
+  // Subreddit link visible in front page feeds
+  const sub = element.querySelector('.subreddit');
+  if (sub) {
+    const subText = sub.textContent.trim();
+    if (subText) parts.push(`[${subText}]`);
+  }
+
+  // Flair
+  const flair = element.querySelector('.linkflairlabel');
+  if (flair) {
+    const flairText = flair.textContent.trim();
+    if (flairText) parts.push(`[Flair: ${flairText}]`);
+  }
+
+  return parts.join(' | ');
+}
+
+function extractOldRedditCommentText(element) {
+  const parts = [];
+
+  const author = element.querySelector('.author');
+  if (author) parts.push(`[u/${author.textContent.trim()}]`);
+
+  // Comment markdown body
+  const body = element.querySelector('.md > p, .usertext-body .md');
+  if (body) {
+    const text = body.textContent.trim();
+    if (text) parts.push(text.slice(0, 400));
+  }
+
+  return parts.join(' | ');
+}
+
+// ---- Adapter ----
+
+const redditAdapter = {
+  platform: 'reddit',
+
+  /**
+   * CSS selectors for content elements to classify.
+   * Covers all three Reddit DOM variants in a single union selector.
+   * IntentKeeperCore will call extractText() to dispatch to the right extractor.
+   */
+  get baseSelector() {
+    if (isOldReddit()) {
+      return [
+        '.thing.link',     // Feed post (link or self post)
+        '.thing.comment',  // Top-level and nested comments
+      ].join(', ');
+    }
+    if (isShreddit()) {
+      return [
+        'shreddit-post',    // Feed cards and post page header
+        'shreddit-comment', // Comments (top-level and nested)
+      ].join(', ');
+    }
+    // Old new Reddit fallback
+    return [
+      'div[data-testid="post-container"]', // Feed post card
+      'div[data-testid="comment"]',        // Comment
+    ].join(', ');
+  },
+
+  /**
+   * The element to receive visual treatment (blur/tag/hide class).
+   * For posts: the post title container.
+   * For comments: the comment body.
+   */
+  getContentElement(element) {
+    const tag = element.tagName.toLowerCase();
+
+    if (tag === 'shreddit-comment') {
+      return element.querySelector('[slot="comment"]') || element;
+    }
+    if (tag === 'shreddit-post') {
+      return element.querySelector('[slot="title"]') || element;
+    }
+    if (element.classList.contains('comment')) {
+      return element.querySelector('.usertext-body, .md') || element;
+    }
+    if (element.classList.contains('link')) {
+      return element.querySelector('p.title, .title') || element;
+    }
+    // New Reddit post container
+    if (element.dataset.testid === 'post-container') {
+      return element.querySelector('h3') || element;
+    }
+    // New Reddit comment
+    if (element.dataset.testid === 'comment') {
+      return element.querySelector('.RichTextJSON-root, p') || element;
+    }
+    return element;
+  },
+
+  /**
+   * No thumbnail blur container needed for Reddit (text-based).
+   * Returns null to fall back to blurring the content element directly.
+   */
+  getBlurContainer(_element) {
+    return null;
+  },
+
+  /**
+   * Dispatch to the correct text extractor based on DOM variant and element type.
+   */
+  extractText(element) {
+    const tag = element.tagName.toLowerCase();
+
+    // Shreddit
+    if (tag === 'shreddit-post') return extractShredditPostText(element);
+    if (tag === 'shreddit-comment') return extractShredditCommentText(element);
+
+    // Old Reddit
+    if (isOldReddit()) {
+      if (element.classList.contains('comment')) return extractOldRedditCommentText(element);
+      if (element.classList.contains('link')) return extractOldRedditPostText(element);
+    }
+
+    // Old new Reddit
+    if (element.dataset.testid === 'comment') return extractNewRedditCommentText(element);
+    return extractNewRedditPostText(element);
+  },
+};
+
+if (typeof IntentKeeperCore !== 'undefined') {
+  IntentKeeperCore.init(redditAdapter);
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { redditAdapter };
+}

--- a/server/api.py
+++ b/server/api.py
@@ -13,9 +13,10 @@ from typing import List, Optional
 import httpx
 import uvicorn
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from .classifier import MAX_CONTENT_LENGTH, IntentClassifier
 
@@ -86,6 +87,21 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+
+# Private Network Access (PNA) middleware.
+# Brave (and Chrome 94+) enforce PNA: requests from extension contexts to
+# localhost must be acknowledged by the server with this response header.
+# Without it, Brave silently blocks the request before it reaches CORS.
+class PrivateNetworkAccessMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        if request.headers.get("Access-Control-Request-Private-Network") == "true":
+            response.headers["Access-Control-Allow-Private-Network"] = "true"
+        return response
+
+
+app.add_middleware(PrivateNetworkAccessMiddleware)
+
 # CORS — restrict to browser extension and localhost origins
 app.add_middleware(
     CORSMiddleware,
@@ -96,7 +112,7 @@ app.add_middleware(
     ],
     allow_credentials=True,
     allow_methods=["*"],
-    allow_headers=["*"],
+    allow_headers=["*", "Access-Control-Request-Private-Network"],
 )
 
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -522,6 +522,58 @@ class TestAPIEndpoints:
         assert response.status_code == 503
 
 
+# --- Private Network Access middleware ---
+
+
+class TestPrivateNetworkAccessMiddleware:
+    """Tests for the PNA middleware that enables Brave/Chrome localhost access."""
+
+    @pytest.mark.asyncio
+    async def test_pna_header_added_when_requested(self):
+        """Server should echo Access-Control-Allow-Private-Network when request header present."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get(
+                "/health",
+                headers={"Access-Control-Request-Private-Network": "true"},
+            )
+        assert response.headers.get("Access-Control-Allow-Private-Network") == "true"
+
+    @pytest.mark.asyncio
+    async def test_pna_header_not_added_without_request(self):
+        """Server should NOT add PNA header when request doesn't ask for it."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get("/health")
+        assert "Access-Control-Allow-Private-Network" not in response.headers
+
+    @pytest.mark.asyncio
+    async def test_pna_header_on_classify_endpoint(self):
+        """PNA header should work on POST endpoints too (classify is the hot path)."""
+        mock_classifier = AsyncMock()
+        mock_classifier.check_health.return_value = True
+        from server.classifier import ClassificationResult
+
+        mock_classifier.classify = AsyncMock(
+            return_value=ClassificationResult(
+                intent="genuine",
+                confidence=0.9,
+                reasoning="Test",
+                action="pass",
+                manipulation_score=0.0,
+            )
+        )
+        with patch("server.api.classifier", mock_classifier):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                response = await ac.post(
+                    "/classify",
+                    json={"content": "Just checking the header"},
+                    headers={"Access-Control-Request-Private-Network": "true"},
+                )
+        assert response.headers.get("Access-Control-Allow-Private-Network") == "true"
+
+
 # --- Classifier internals ---
 
 

--- a/tests/test_reddit_adapter.py
+++ b/tests/test_reddit_adapter.py
@@ -1,0 +1,143 @@
+"""
+Tests for the Reddit platform adapter.
+
+Since the adapter is JavaScript, these tests validate:
+- File exists and is syntactically coherent (basic string checks)
+- Required adapter interface is present (platform, baseSelector, extractText, etc.)
+- All three Reddit variants are handled (shreddit, new reddit, old reddit)
+- Manifest includes reddit.com matches
+
+JS-level unit tests (DOM manipulation, extraction logic) would require a Node.js
+test runner (Jest/Vitest). These Python tests guard the structural contract.
+"""
+
+import json
+from pathlib import Path
+
+EXTENSION_DIR = Path(__file__).parent.parent / "extension"
+REDDIT_JS = EXTENSION_DIR / "platforms" / "reddit.js"
+MANIFEST = EXTENSION_DIR / "manifest.json"
+
+
+class TestRedditAdapterFile:
+    """Validate reddit.js exists and has the required adapter interface."""
+
+    def test_reddit_js_exists(self):
+        assert REDDIT_JS.exists(), "extension/platforms/reddit.js not found"
+
+    def test_adapter_object_defined(self):
+        src = REDDIT_JS.read_text()
+        assert "redditAdapter" in src
+
+    def test_platform_field_set(self):
+        src = REDDIT_JS.read_text()
+        assert "platform: 'reddit'" in src
+
+    def test_base_selector_defined(self):
+        src = REDDIT_JS.read_text()
+        assert "baseSelector" in src
+
+    def test_get_content_element_defined(self):
+        src = REDDIT_JS.read_text()
+        assert "getContentElement" in src
+
+    def test_get_blur_container_defined(self):
+        src = REDDIT_JS.read_text()
+        assert "getBlurContainer" in src
+
+    def test_extract_text_defined(self):
+        src = REDDIT_JS.read_text()
+        assert "extractText" in src
+
+    def test_intentkeepercore_init_called(self):
+        src = REDDIT_JS.read_text()
+        assert "IntentKeeperCore.init(redditAdapter)" in src
+
+    def test_module_exports_for_testing(self):
+        src = REDDIT_JS.read_text()
+        assert "module.exports" in src
+
+
+class TestRedditVariantCoverage:
+    """Confirm all three Reddit DOM variants are handled."""
+
+    def test_shreddit_post_handled(self):
+        src = REDDIT_JS.read_text()
+        assert "shreddit-post" in src
+
+    def test_shreddit_comment_handled(self):
+        src = REDDIT_JS.read_text()
+        assert "shreddit-comment" in src
+
+    def test_old_new_reddit_handled(self):
+        src = REDDIT_JS.read_text()
+        # Old new Reddit uses data-testid attributes
+        assert "data-testid" in src
+        assert "post-container" in src
+
+    def test_old_reddit_handled(self):
+        src = REDDIT_JS.read_text()
+        assert "old.reddit.com" in src
+        assert ".thing.link" in src
+        assert ".thing.comment" in src
+
+    def test_isOldReddit_detection(self):
+        src = REDDIT_JS.read_text()
+        assert "isOldReddit" in src
+
+    def test_isShreddit_detection(self):
+        src = REDDIT_JS.read_text()
+        assert "isShreddit" in src
+
+    def test_comment_text_capped(self):
+        """Comment text should be sliced to prevent very long LLM prompts."""
+        src = REDDIT_JS.read_text()
+        assert "slice(0, 400)" in src
+
+    def test_subreddit_context_included(self):
+        """Subreddit name should be included in extracted text for context."""
+        src = REDDIT_JS.read_text()
+        assert "subreddit" in src.lower()
+
+
+class TestManifestRedditMatches:
+    """Validate manifest.json includes Reddit URL matches."""
+
+    def test_manifest_has_reddit_matches(self):
+        manifest = json.loads(MANIFEST.read_text())
+        all_matches = []
+        for entry in manifest.get("content_scripts", []):
+            all_matches.extend(entry.get("matches", []))
+        reddit_matches = [m for m in all_matches if "reddit" in m]
+        assert len(reddit_matches) > 0, "No Reddit URLs in manifest content_scripts"
+
+    def test_manifest_covers_new_reddit(self):
+        manifest = json.loads(MANIFEST.read_text())
+        all_matches = []
+        for entry in manifest.get("content_scripts", []):
+            all_matches.extend(entry.get("matches", []))
+        assert any("www.reddit.com" in m for m in all_matches)
+
+    def test_manifest_covers_old_reddit(self):
+        manifest = json.loads(MANIFEST.read_text())
+        all_matches = []
+        for entry in manifest.get("content_scripts", []):
+            all_matches.extend(entry.get("matches", []))
+        assert any("old.reddit.com" in m for m in all_matches)
+
+    def test_manifest_reddit_uses_classifier_core(self):
+        manifest = json.loads(MANIFEST.read_text())
+        for entry in manifest.get("content_scripts", []):
+            if any("reddit" in m for m in entry.get("matches", [])):
+                assert "core/classifier.js" in entry.get("js", [])
+                assert "platforms/reddit.js" in entry.get("js", [])
+                break
+        else:
+            raise AssertionError("No Reddit content script entry found")
+
+    def test_manifest_reddit_includes_styles(self):
+        manifest = json.loads(MANIFEST.read_text())
+        for entry in manifest.get("content_scripts", []):
+            if any("reddit" in m for m in entry.get("matches", [])):
+                assert "styles.css" in entry.get("css", [])
+                break


### PR DESCRIPTION
## Summary

- **Brave browser support**: Private Network Access middleware in the server so Brave Shields don't block localhost requests
- **Reddit Phase 4**: Full platform adapter covering all three Reddit DOM variants

## Brave Support

Brave enforces Private Network Access (PNA) strictly. When the extension's background service worker calls `localhost:8420`, Brave sends `Access-Control-Request-Private-Network: true`. Without a corresponding `Access-Control-Allow-Private-Network: true` response header, Brave silently drops the request.

The new `PrivateNetworkAccessMiddleware` handles this:
```python
if request.headers.get("Access-Control-Request-Private-Network") == "true":
    response.headers["Access-Control-Allow-Private-Network"] = "true"
```

No extension changes needed - the background.js proxy architecture already handles the rest.

## Reddit Adapter

Three Reddit DOM variants in a single adapter:

| Variant | Selectors | Detection |
|---|---|---|
| Shreddit (current) | `shreddit-post`, `shreddit-comment` | `isShreddit()` checks for `<shreddit-app>` |
| Old new Reddit | `div[data-testid="post-container/comment"]` | Default fallback |
| Old Reddit | `.thing.link`, `.thing.comment` | `isOldReddit()` checks hostname |

Extracts: post title, subreddit name, post flair, author, comment body (capped at 400 chars for prompt efficiency).

## Tests

- 3 PNA middleware tests (Python/pytest)
- 22 Reddit adapter structural tests (validates adapter contract + manifest coverage)

83 tests passing total.