### PR TITLE
fix: resolve CodeQL URL sanitization false positives in Reddit adapter tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,8 +294,8 @@ See [ROADMAP.md](ROADMAP.md) for the phased implementation plan:
 - Phase 1: Core classifier + Chrome extension (Twitter/X) ✅
 - Phase 2: Hardening & reliability ✅
 - Phase 3: YouTube support
-- Phase 4: Reddit support
-- Phase 5: Classification accuracy
+- Phase 4: Reddit support ✅ (3-variant DOM adapter, 22 tests)
+- Phase 5: Classification accuracy ✅ (98%, 78/80, prompt ceiling reached)
 - Phase 6: User-configurable sensitivity
 - Phase 7: Statistics dashboard
-- Phase 8: Multi-browser support (Brave, Edge, Opera, Firefox)
+- Phase 8: Multi-browser support - Brave ✅ (PNA middleware); Edge/Opera/Firefox 🔜

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -148,15 +148,17 @@
 
 ---
 
-## Phase 4: Reddit Support 🔜 PLANNED
+## Phase 4: Reddit Support ✅ COMPLETE
 
 **Goal**: Extend classification to Reddit posts and comments.
 
-### 4.1 Reddit Content Script
-- [ ] Create `extension/platforms/reddit.js`
-- [ ] Handle old.reddit.com and new Reddit
-- [ ] Intercept post titles in feeds
-- [ ] Intercept comment content
+### 4.1 Reddit Content Script ✅
+- [x] Create `extension/platforms/reddit.js`
+- [x] Handle old.reddit.com, new Reddit (React), and Shreddit (web components) - all three DOM variants
+- [x] Intercept post titles in feeds
+- [x] Intercept comment content (capped at 400 chars to prevent long LLM prompts)
+- [x] Include subreddit context in extracted text
+- [x] 22 structural tests in `tests/test_reddit_adapter.py`
 
 ### 4.2 Reddit-Specific Intents
 - [ ] Add `karma_farming` intent
@@ -255,11 +257,11 @@
 
 **Goal**: Bring IntentKeeper to all major browsers.
 
-### 8.1 Chromium Browsers (Brave, Edge, Opera)
+### 8.1 Chromium Browsers (Brave, Edge, Opera) - Brave ✅
 
 Brave, Edge, and Opera all run Chromium and support Manifest V3 natively - the extension works on them without code changes. Work here is testing and store submissions only.
 
-- [ ] Test full feature set on Brave (Private Network Access behavior may differ slightly)
+- [x] Brave Private Network Access (PNA) support: `PrivateNetworkAccessMiddleware` added to API server - responds with `Access-Control-Allow-Private-Network: true` when Brave's PNA preflight fires. 3 tests in `TestPrivateNetworkAccessMiddleware`.
 - [ ] Test on Microsoft Edge - verify `chrome.*` API aliases work as expected
 - [ ] Test on Opera
 - [ ] Submit to Microsoft Edge Add-ons store

--- a/tests/test_reddit_adapter.py
+++ b/tests/test_reddit_adapter.py
@@ -77,7 +77,8 @@ class TestRedditVariantCoverage:
 
     def test_old_reddit_handled(self):
         src = REDDIT_JS.read_text()
-        assert "old.reddit.com" in src
+        # Check for the JS string literal as used in the isOldReddit hostname comparison
+        assert "'old.reddit.com'" in src
         assert ".thing.link" in src
         assert ".thing.comment" in src
 
@@ -116,14 +117,14 @@ class TestManifestRedditMatches:
         all_matches = []
         for entry in manifest.get("content_scripts", []):
             all_matches.extend(entry.get("matches", []))
-        assert any("www.reddit.com" in m for m in all_matches)
+        assert "https://www.reddit.com/*" in all_matches
 
     def test_manifest_covers_old_reddit(self):
         manifest = json.loads(MANIFEST.read_text())
         all_matches = []
         for entry in manifest.get("content_scripts", []):
             all_matches.extend(entry.get("matches", []))
-        assert any("old.reddit.com" in m for m in all_matches)
+        assert "https://old.reddit.com/*" in all_matches
 
     def test_manifest_reddit_uses_classifier_core(self):
         manifest = json.loads(MANIFEST.read_text())


### PR DESCRIPTION
## Problem

Three code scanning alerts (severity: warning) in `tests/test_reddit_adapter.py`:

> Incomplete URL substring sanitization - The string old.reddit.com may be at an arbitrary position in the sanitized URL.

## Root cause

CodeQL's `py/incomplete-url-sanitization` rule fires on `"hostname.com" in some_string` because it looks like a URL security check that could be bypassed (e.g. `evil.com/old.reddit.com` would pass). These assertions are not security checks - they're structural tests verifying source file content and manifest entries.

## Fix

| Location | Old (flagged) | New (clear intent) |
|---|---|---|
| Line 80 - JS source check | `"old.reddit.com" in src` | `"'old.reddit.com'" in src` (JS string literal with quotes) |
| Line 119 - manifest check | `any("www.reddit.com" in m for m in all_matches)` | `"https://www.reddit.com/*" in all_matches` (exact membership) |
| Line 126 - manifest check | `any("old.reddit.com" in m for m in all_matches)` | `"https://old.reddit.com/*" in all_matches` (exact membership) |

The manifest checks are actually *more precise* now - they verify the exact URL pattern, not just that the domain name appears somewhere in any match string.

## Test plan

- [x] `pytest tests/test_reddit_adapter.py` - 22 passed
- [ ] CI green; CodeQL alerts should close automatically