### PR TITLE
docs: add doc maintenance rules and fix stale architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,14 @@ python eval/run_eval.py           # measure improvement
 # only commit if accuracy is >= baseline
 ```
 
+**Workflow for real-world misclassifications (spotted during use):**
+1. Note the content and what it was classified as vs. what it should be
+2. Add it to `eval/test_set.yaml` with the correct label and a `reasoning` note explaining the boundary
+3. Run `python eval/run_eval.py` - this becomes the new baseline
+4. Adjust `scenarios/intents.yaml` (add a rule or example) to fix it
+5. Run eval again - only commit if accuracy >= baseline
+6. If fixing it breaks something else, you've hit a model boundary - document it in CLAUDE.md and leave it
+
 The 2 remaining wrong classifications (2%) are at the model-training boundary:
 - `Millennials ruined the housing market. It's really that simple.` - model reads 'really that simple' as contemptuous; requires fine-tuning to fix
 - `People who recline their airplane seat are inconsiderate. Change my mind.` - model reads 'Change my mind' as contempt language; prompt rules can't reliably override this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,37 @@ IntentKeeper shares patterns with [empathySync](https://github.com/Olawoyin007/e
 - Classification pipeline architecture
 - Local-first philosophy
 
+## Documentation Maintenance
+
+**Rule: docs must be updated before merging any PR that changes behavior, structure, or features. Never leave docs stale.**
+
+| Document | Update when |
+|----------|-------------|
+| `README.md` | New features shipped, browser support changes, accuracy baseline changes, new platform support |
+| `ROADMAP.md` | Phase completed - mark ✅; new phase planned - add entry |
+| `docs/architecture.md` | Intent categories change, new platform adapter added, browser support changes, component relationships change |
+| `CLAUDE.md` (this file) | Eval baseline changes, new intent categories, architecture changes, new environment variables |
+
+### Per-change checklist
+
+**New platform supported (Reddit, YouTube, etc.):**
+- [ ] docs/architecture.md: update High-Level Overview (browser line, Extension section), Component Relationships
+- [ ] ROADMAP.md: mark phase ✅
+- [ ] README.md: update supported platforms list
+- [ ] CLAUDE.md: update Architecture section if new files added
+
+**Intent categories changed (added, removed, renamed):**
+- [ ] docs/architecture.md: update Intent Categories section (count, spectrum diagram)
+- [ ] CLAUDE.md: update intent table
+- [ ] eval/test_set.yaml: add/update examples
+
+**Eval baseline changes:**
+- [ ] CLAUDE.md: update baseline percentage and date in Eval Harness section
+
+**New browser support:**
+- [ ] docs/architecture.md: update "Browser (Chrome)" in High-Level Overview to include new browser
+- [ ] README.md: update browser compatibility
+
 ## Roadmap
 
 See [ROADMAP.md](ROADMAP.md) for the phased implementation plan:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,9 +9,10 @@ This document provides a visual overview of IntentKeeper's architecture. For det
 │                         User's Machine                              │
 │                                                                      │
 │  ┌──────────────────────────────────────────────────────────────┐   │
-│  │                   Browser (Chrome)                            │   │
+│  │              Browser (Chrome / Brave)                        │   │
 │  │  ┌─────────────┐                                             │   │
-│  │  │  Extension   │ ◄── Intercepts content from Twitter/X       │   │
+│  │  │  Extension   │ ◄── Intercepts content from Twitter/X,      │   │
+│  │  │              │     Reddit (shreddit, new, old variants)    │   │
 │  │  │  content.js  │                                             │   │
 │  │  └──────┬──────┘                                              │   │
 │  │         │ POST /classify                                      │   │
@@ -105,13 +106,19 @@ Visual Treatment Applied (content.js)
 │                    Browser Extension                            │
 │                                                                 │
 │  ┌─────────────────┐  ┌──────────────┐  ┌──────────────────┐  │
-│  │   content.js     │  │ background.js│  │  popup/popup.js  │  │
-│  │                  │  │              │  │                  │  │
+│  │core/classifier.js│  │ background.js│  │  popup/popup.js  │  │
+│  │ (IntentKeeperCore│  │              │  │                  │  │
 │  │ - DOM observation│  │ - Settings   │  │ - Toggle UI      │  │
-│  │ - Tweet intercept│  │ - Health poll│  │ - Sliders        │  │
-│  │ - API calls      │  │ - Badge icon │  │ - Status display │  │
-│  │ - CSS treatments │  │              │  │                  │  │
+│  │ - API calls      │  │ - Health poll│  │ - Sliders        │  │
+│  │ - CSS treatments │  │ - Badge icon │  │ - Status display │  │
+│  │ - PNA middleware │  │ - PNA proxy  │  │                  │  │
 │  └────────┬─────────┘  └──────────────┘  └──────────────────┘  │
+│           │ uses platform adapters                               │
+│  ┌────────┴──────────────────────────────────────────────────┐  │
+│  │  Platform Adapters (extension/platforms/)                  │  │
+│  │  twitter.js - Twitter/X DOM (tweets)                       │  │
+│  │  reddit.js  - Reddit DOM (shreddit, new reddit, old reddit)│  │
+│  └────────┬──────────────────────────────────────────────────┘  │
 │           │                                                      │
 └───────────┼──────────────────────────────────────────────────────┘
             │ HTTP (localhost:8420)
@@ -141,7 +148,7 @@ Visual Treatment Applied (content.js)
 ┌────────────────────────────────────────────────────────────────┐
 │                   scenarios/intents.yaml                        │
 │                                                                 │
-│   - 7 intent categories with weights and actions               │
+│   - 6 intent categories with weights and actions               │
 │   - Few-shot examples for accuracy                             │
 │   - Classification rules for LLM prompt                        │
 │   - Indicator lists for each intent                            │
@@ -171,11 +178,12 @@ Visual Treatment Applied (content.js)
 │   │ → tag    │ │ → hide   │                                      │
 │   └──────────┘ └──────────┘                                      │
 │                                                                  │
-│                              ┌──────────┐ ┌──────────┐          │
-│                              │ genuine  │ │ neutral  │          │
-│                              │ wt: 0.0  │ │ wt: 0.0  │          │
-│                              │ → pass   │ │ → pass   │          │
-│                              └──────────┘ └──────────┘          │
+│                              ┌──────────┐                        │
+│                              │ genuine  │                        │
+│                              │ wt: 0.0  │                        │
+│                              │ → pass   │                        │
+│                              └──────────┘                        │
+│   (neutral is error fallback only, not a primary category)       │
 │                                                                  │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -205,7 +213,7 @@ Visual Treatment Applied (content.js)
 │   │ ▶ Hidden: engagement bait (click to expand)      │           │
 │   └─────────────────────────────────────────────────┘           │
 │                                                                  │
-│   PASS (genuine, neutral)                                        │
+│   PASS (genuine)                                                 │
 │   ┌─────────────────────────────────────────────────┐           │
 │   │ Content displayed normally, no modification.     │           │
 │   └─────────────────────────────────────────────────┘           │


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: added Documentation Maintenance section with per-change checklists (new platform, intent changes, eval baseline changes, new browser support)
- **docs/architecture.md**: fixed multiple stale references:
  - Browser label: "Chrome" → "Chrome / Brave"
  - Extension now shows Twitter/X AND Reddit (3 DOM variants: shreddit, new, old)
  - Restructured Browser Extension component: `core/classifier.js` + platform adapters (`twitter.js`, `reddit.js`)
  - Intent count: 7 → 6 categories
  - Intent spectrum: removed `neutral` box (neutral is error fallback only, not a primary category)
  - PASS label: "genuine, neutral" → "genuine"

## Test plan
- [ ] Verify architecture.md renders correctly in GitHub markdown
- [ ] Verify intent spectrum diagram matches actual `scenarios/intents.yaml`
- [ ] Verify component diagram matches actual extension file structure