### PR TITLE
fix: YouTube lazy-load bug + on-page status badge

### DIFF
--- a/extension/core/classifier.js
+++ b/extension/core/classifier.js
@@ -39,6 +39,9 @@ let isProcessing = false;
 // Flag: new items arrived while a batch was in-flight
 let pendingReprocess = false;
 
+// Running count of classified items (shown in status badge)
+let classifiedCount = 0;
+
 // Debug logger - only logs when debug._enabled is true
 const debug = {
   _enabled: false,
@@ -263,6 +266,8 @@ function applyTreatment(element, classification, adapter) {
 
   element.setAttribute(PROCESSED_ATTR, 'true');
   element.setAttribute(INTENT_ATTR, intent);
+  classifiedCount++;
+  updateStatusBadge();
 
   if (settings.showTags) {
     applyTag(element, intent, confidence);
@@ -317,7 +322,12 @@ async function processItems(adapter) {
       const text = adapter.extractText(item);
       const mediaUrls = adapter.extractMediaUrls ? adapter.extractMediaUrls(item) : [];
       if (text.length < MIN_CONTENT_LENGTH) {
-        item.setAttribute(PROCESSED_ATTR, 'skipped');
+        // Only permanently skip items with SOME text (genuinely short content).
+        // Empty string means the element is still loading (lazy render) -
+        // leave it unmarked so the next observer pass can pick it up.
+        if (text.length > 0) {
+          item.setAttribute(PROCESSED_ATTR, 'skipped');
+        }
       } else {
         item.classList.add('intentkeeper-classifying');
         itemData.push({ item, text, mediaUrls });
@@ -347,6 +357,40 @@ async function processItems(adapter) {
       processItems(adapter);
     }
   }
+}
+
+// --- Status Badge ---
+
+function createStatusBadge(platform, connected) {
+  const existing = document.getElementById('intentkeeper-status-badge');
+  if (existing) existing.remove();
+
+  const badge = document.createElement('div');
+  badge.id = 'intentkeeper-status-badge';
+  if (!connected) badge.classList.add('ik-disconnected');
+
+  const label = platform.charAt(0).toUpperCase() + platform.slice(1);
+  badge.innerHTML = `
+    <span class="ik-dot"></span>
+    <span class="ik-label">&#x1f6e1;&#xfe0f; ${label}</span>
+    <span class="ik-count"></span>
+  `;
+  document.body.appendChild(badge);
+
+  if (connected) {
+    badge._hideTimer = setTimeout(() => badge.classList.add('ik-faded'), 4000);
+  }
+  return badge;
+}
+
+function updateStatusBadge() {
+  const badge = document.getElementById('intentkeeper-status-badge');
+  if (!badge) return;
+  const countEl = badge.querySelector('.ik-count');
+  if (countEl) countEl.textContent = `· ${classifiedCount} classified`;
+  badge.classList.remove('ik-faded');
+  clearTimeout(badge._hideTimer);
+  badge._hideTimer = setTimeout(() => badge.classList.add('ik-faded'), 3000);
 }
 
 function setupObserver(adapter) {
@@ -380,18 +424,23 @@ window.IntentKeeperCore = {
       return;
     }
 
+    let connected = false;
     try {
       const health = await chrome.runtime.sendMessage({ type: 'CHECK_HEALTH' });
       if (!health || health.status === 'disconnected') {
         debug.error('API not available');
+        createStatusBadge(adapter.platform, false);
         return;
       }
+      connected = true;
       debug.log(`API connected (model: ${health.model})`);
     } catch (e) {
       debug.error('Cannot connect to background worker', e.message || e);
+      createStatusBadge(adapter.platform, false);
       return;
     }
 
+    createStatusBadge(adapter.platform, connected);
     processItems(adapter);
     setupObserver(adapter);
 

--- a/extension/platforms/youtube.js
+++ b/extension/platforms/youtube.js
@@ -12,11 +12,13 @@
 // ---- Per-type text extraction helpers ----
 
 function extractVideoCardText(element) {
-  const parts = [];
-
-  // Title is the primary classification signal
+  // Title is the primary classification signal. If it isn't rendered yet
+  // (YouTube lazy-loads card content), return '' so the item stays unmarked
+  // and gets picked up again on the next observer pass.
   const title = element.querySelector('#video-title');
-  if (title) parts.push(title.textContent.trim());
+  if (!title || !title.textContent.trim()) return '';
+
+  const parts = [title.textContent.trim()];
 
   // Channel name - helps detect known bait channels
   const channel = element.querySelector('ytd-channel-name #text, #channel-name #text');

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -166,3 +166,51 @@
   background: rgba(30, 144, 255, 0.2);
   color: #1e90ff;
 }
+
+/* On-page status badge */
+#intentkeeper-status-badge {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  background: rgba(15, 15, 15, 0.85);
+  color: #ccc;
+  font-size: 11px;
+  font-family: -apple-system, system-ui, BlinkMacSystemFont, sans-serif;
+  padding: 5px 10px;
+  border-radius: 20px;
+  z-index: 2147483647;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(6px);
+  pointer-events: none;
+  transition: opacity 0.4s ease;
+  opacity: 1;
+  line-height: 1;
+}
+
+#intentkeeper-status-badge.ik-faded {
+  opacity: 0;
+}
+
+#intentkeeper-status-badge .ik-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #4caf50;
+  flex-shrink: 0;
+}
+
+#intentkeeper-status-badge.ik-disconnected .ik-dot {
+  background: #f44336;
+}
+
+#intentkeeper-status-badge.ik-disconnected {
+  opacity: 1 !important;
+  color: #f44336;
+}
+
+#intentkeeper-status-badge .ik-count {
+  color: #666;
+}


### PR DESCRIPTION
## Problem

YouTube lazy-loads card content. Element shells appear in the DOM before titles are filled in. The classifier ran on these empty shells, got 0 chars < 20 min, and permanently marked them `data-intentkeeper-processed="skipped"`. The `:not([data-intentkeeper-processed])` selector then excluded them forever - even after YouTube filled the title in. Result: nothing ever classified on YouTube.

## Fix

**classifier.js**: Only permanently mark items as `skipped` when `text.length > 0` (genuinely short content). Items with 0 chars (still loading) stay unmarked and are picked up on the next MutationObserver pass.

**youtube.js**: `extractVideoCardText` returns `''` immediately if `#video-title` is absent or empty - belt-and-suspenders for the same issue, and avoids sending a channel-name-only string to the classifier.

## Status badge

Small floating pill at bottom-right on every supported page:
- Shows `🛡️ YouTube · Connected · 12 classified` (updates live)
- Fades out after 3s of inactivity when connected
- Stays visible with red dot if server is disconnected
- `pointer-events: none` so it never blocks clicks

## Test plan
- [ ] Load YouTube homepage - items should get tags after a second
- [ ] Badge appears bottom-right, fades after ~3s, reappears on scroll
- [ ] Stop the server - badge shows red dot
- [ ] Twitter and Reddit still work (no regression)