### PR TITLE
fix: YouTube SPA navigation, observer hardening, Reddit comment context

### DIFF
--- a/extension/core/classifier.js
+++ b/extension/core/classifier.js
@@ -39,7 +39,8 @@ let isProcessing = false;
 // Flag: new items arrived while a batch was in-flight
 let pendingReprocess = false;
 
-// Running count of classified items (shown in status badge)
+// Counts for status badge diagnostics
+let foundCount = 0;
 let classifiedCount = 0;
 
 // Debug logger - only logs when debug._enabled is true
@@ -314,6 +315,7 @@ async function processItems(adapter) {
 
   isProcessing = true;
   try {
+    updateStatusBadge('scanning');
     const selector = buildSelector(adapter.baseSelector, PROCESSED_ATTR);
     const items = Array.from(document.querySelectorAll(selector));
 
@@ -330,6 +332,7 @@ async function processItems(adapter) {
         }
       } else {
         item.classList.add('intentkeeper-classifying');
+        foundCount++;
         itemData.push({ item, text, mediaUrls });
       }
     }
@@ -346,6 +349,7 @@ async function processItems(adapter) {
           applyTreatment(item, classification, adapter);
         } else {
           item.setAttribute(PROCESSED_ATTR, 'failed');
+          updateStatusBadge();
         }
       }
     }
@@ -383,14 +387,30 @@ function createStatusBadge(platform, connected) {
   return badge;
 }
 
-function updateStatusBadge() {
+function updateStatusBadge(state) {
   const badge = document.getElementById('intentkeeper-status-badge');
   if (!badge) return;
   const countEl = badge.querySelector('.ik-count');
-  if (countEl) countEl.textContent = `· ${classifiedCount} classified`;
+  if (countEl) {
+    if (state === 'scanning') {
+      countEl.textContent = '· scanning...';
+    } else if (foundCount > 0 && classifiedCount === 0) {
+      // Items found but nothing classified - likely API issue
+      countEl.textContent = `· ${foundCount} found, 0 classified`;
+      badge.classList.add('ik-warn');
+    } else if (classifiedCount > 0) {
+      countEl.textContent = `· ${classifiedCount} classified`;
+      badge.classList.remove('ik-warn');
+    } else {
+      countEl.textContent = '';
+    }
+  }
   badge.classList.remove('ik-faded');
   clearTimeout(badge._hideTimer);
-  badge._hideTimer = setTimeout(() => badge.classList.add('ik-faded'), 3000);
+  // Don't auto-hide if there's a warning
+  if (!badge.classList.contains('ik-warn')) {
+    badge._hideTimer = setTimeout(() => badge.classList.add('ik-faded'), 3000);
+  }
 }
 
 function setupObserver(adapter) {
@@ -402,8 +422,15 @@ function setupObserver(adapter) {
 
   observer.observe(document.body, {
     childList: true,
-    subtree: true
+    subtree: true,
+    // Also watch text node changes - catches platforms that update existing
+    // elements' text content (e.g. YouTube recycling card elements on scroll)
+    characterData: true
   });
+
+  // Periodic fallback scan every 3s. Catches any items the MutationObserver
+  // missed (e.g. content rendered via requestAnimationFrame after mutations).
+  setInterval(() => processItems(adapter), 3000);
 }
 
 // --- Public API ---
@@ -443,6 +470,16 @@ window.IntentKeeperCore = {
     createStatusBadge(adapter.platform, connected);
     processItems(adapter);
     setupObserver(adapter);
+
+    // Optional SPA navigation hook - platform adapters implement this
+    // to reset counts and re-scan after client-side navigation completes.
+    if (adapter.setupNavigation) {
+      adapter.setupNavigation(() => {
+        foundCount = 0;
+        classifiedCount = 0;
+        processItems(adapter);
+      });
+    }
 
     debug.log(`Active [${adapter.platform}]`);
   }

--- a/extension/platforms/reddit.js
+++ b/extension/platforms/reddit.js
@@ -14,6 +14,34 @@
  * All classification logic lives in core/classifier.js.
  */
 
+// ---- Page-level post title (for comment context) ----
+
+/**
+ * On a thread/comment page, return the post title so comment classifiers
+ * can include it as context - the same way Twitter includes the focal post
+ * for replies. Returns null on feed/listing pages where there's no single post.
+ */
+function getPagePostTitle() {
+  // Shreddit: post-title attribute on the <shreddit-post> custom element
+  const shredditPost = document.querySelector('shreddit-post');
+  if (shredditPost) {
+    const attr = shredditPost.getAttribute('post-title');
+    if (attr) return attr.trim();
+    const slot = shredditPost.querySelector('[slot="title"]');
+    if (slot) return slot.textContent.trim() || null;
+  }
+
+  // New Reddit thread page
+  const newH1 = document.querySelector('[data-test-id="post-content"] h1, h1[id^="post-title"]');
+  if (newH1) return newH1.textContent.trim() || null;
+
+  // Old Reddit thread page
+  const oldTitle = document.querySelector('.top-matter p.title a');
+  if (oldTitle) return oldTitle.textContent.trim() || null;
+
+  return null;
+}
+
 // ---- Reddit variant detection ----
 
 function isOldReddit() {
@@ -64,6 +92,11 @@ function extractShredditCommentText(element) {
 
   const parts = [];
 
+  // Include the post title as context so the classifier knows what is being
+  // commented on (same pattern as Twitter's focal post context for replies)
+  const postTitle = getPagePostTitle();
+  if (postTitle) parts.push(`[Post: ${postTitle}]`);
+
   const author = element.getAttribute('author');
   if (author) parts.push(`[u/${author}]`);
 
@@ -105,6 +138,9 @@ function extractNewRedditCommentText(element) {
 
   const parts = [];
 
+  const postTitle = getPagePostTitle();
+  if (postTitle) parts.push(`[Post: ${postTitle}]`);
+
   const author = element.querySelector('[data-testid="comment_author_link"], a[href*="/user/"]');
   if (author) parts.push(`[${author.textContent.trim()}]`);
 
@@ -143,6 +179,9 @@ function extractOldRedditCommentText(element) {
   if (!body || !body.textContent.trim()) return '';
 
   const parts = [];
+
+  const postTitle = getPagePostTitle();
+  if (postTitle) parts.push(`[Post: ${postTitle}]`);
 
   const author = element.querySelector('.author');
   if (author) parts.push(`[u/${author.textContent.trim()}]`);

--- a/extension/platforms/youtube.js
+++ b/extension/platforms/youtube.js
@@ -140,6 +140,16 @@ const youtubeAdapter = {
     if (tag === 'ytd-comment-thread-renderer') return extractCommentText(element);
     if (tag === 'ytd-watch-metadata') return extractWatchMetadataText(element);
     return extractVideoCardText(element);
+  },
+
+  /**
+   * YouTube SPA navigation hook.
+   * YouTube fires 'yt-navigate-finish' when client-side navigation completes
+   * and the new page's content is in the DOM. Without this, the MutationObserver
+   * may fire on the navigation skeleton before content is ready.
+   */
+  setupNavigation(reprocess) {
+    document.addEventListener('yt-navigate-finish', reprocess);
   }
 };
 

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -214,3 +214,11 @@
 #intentkeeper-status-badge .ik-count {
   color: #666;
 }
+
+#intentkeeper-status-badge.ik-warn .ik-count {
+  color: #f4a336;
+}
+
+#intentkeeper-status-badge.ik-warn {
+  opacity: 1 !important;
+}


### PR DESCRIPTION
## YouTube fixes

Three independent issues that together explain why YouTube classification wasn't working:

**1. SPA navigation** - YouTube fires `yt-navigate-finish` when client-side navigation completes. Without listening to this, processItems could run on the navigation skeleton before content is in the DOM. Added `setupNavigation` hook to the adapter interface; YouTube adapter listens to `yt-navigate-finish` and triggers a fresh scan.

**2. `characterData: true` on MutationObserver** - YouTube recycles existing DOM elements when scrolling (updates text nodes in place rather than replacing child elements). `childList: true` alone misses these. Added `characterData: true` to catch text node updates.

**3. Periodic fallback scan** - Content rendered via `requestAnimationFrame` or deferred timers emits no mutations. A 3s interval scan catches anything the observer misses.

**Bonus: diagnostic badge** - Badge now shows amber "N found, 0 classified" if items were found but batch classification returned nothing. Makes API failures immediately visible without DevTools.

## Reddit comment context

`getPagePostTitle()` reads the thread's post title (Shreddit attribute / new Reddit h1 / old Reddit `.top-matter`). All three comment extractors now prepend `[Post: title]` when on a thread page - same as Twitter's focal post context for replies.

## Test plan
- [ ] YouTube home page: badge appears, items get tags after scrolling
- [ ] YouTube: navigate to a video and back - items on home page re-classified
- [ ] Reddit thread: comment tags include the post title in classifier reasoning
- [ ] Reddit feed: comment context absent (no single post), no regression
- [ ] Twitter: no regression