### PR TITLE
ci: upgrade actions to Node.js 24, fix extension-lint, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -63,14 +63,17 @@ jobs:
   extension-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate manifest.json
         run: python -c "import json; json.load(open('extension/manifest.json'))"
 
       - name: Check extension files exist
         run: |
-          test -f extension/content.js
+          test -f extension/core/classifier.js
+          test -f extension/platforms/twitter.js
+          test -f extension/platforms/reddit.js
+          test -f extension/platforms/youtube.js
           test -f extension/background.js
           test -f extension/styles.css
           test -f extension/popup/popup.html

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,10 +18,10 @@ jobs:
     name: Dependency Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -40,25 +40,27 @@ jobs:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
 
       - name: Run CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
 
   secrets-scan:
     name: Secrets Scan
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true  # gitleaks has no Node.js 24 build yet
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Scan for hardcoded secrets
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -49,11 +49,19 @@ async function saveSettings() {
 }
 
 /**
- * Check API health via background worker
+ * Check API health via background worker.
+ * Wraps sendMessage in a 5s timeout - MV3 service workers can be dormant
+ * and Chrome sometimes fails to wake them, leaving sendMessage hanging forever.
  */
 async function checkHealth() {
   try {
-    const data = await chrome.runtime.sendMessage({ type: 'CHECK_HEALTH' });
+    const timeout = new Promise((_, reject) =>
+      setTimeout(() => reject(new Error('timeout')), 5000)
+    );
+    const data = await Promise.race([
+      chrome.runtime.sendMessage({ type: 'CHECK_HEALTH' }),
+      timeout
+    ]);
 
     if (data && data.status === 'ok') {
       elements.status.className = 'status connected';


### PR DESCRIPTION
## Changes

- `checkout@v4` → `checkout@v6`
- `setup-python@v5` → `setup-python@v6`
- `cache@v4` → `cache@v5`
- `codeql-action/init@v3` → `v4` (v3 deprecated December 2026)
- `gitleaks@v2` → `v2.3.9` + `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` (no Node.js 24 build from gitleaks yet)
- Added `dependabot.yml` for weekly Actions version tracking
- Fixed `extension-lint`: `content.js` check updated to `core/classifier.js` + all platform adapters (file was removed in the platform refactor)