### PR TITLE
docs: add full browser support - Chrome, Brave, Edge, Opera

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="assets/logo.png" alt="IntentKeeper" width="180">
+  <img src="assets/logo.png" alt="intentKeeper" width="180">
 </p>
 
-<h1 align="center">IntentKeeper</h1>
+<h1 align="center">intentKeeper</h1>
 
 <p align="center"><strong>A digital bodyguard for your mind.</strong></p>
 
@@ -14,6 +14,7 @@
   <img src="https://img.shields.io/badge/platform-Reddit-FF4500.svg" alt="Platform: Reddit">
   <img src="https://img.shields.io/badge/accuracy-98%25-brightgreen.svg" alt="Accuracy: 98%">
   <img src="https://img.shields.io/badge/local--first-Ollama-orange.svg" alt="Local-First: Ollama">
+  <img src="https://img.shields.io/badge/browser-Chrome%20%7C%20Brave%20%7C%20Edge%20%7C%20Opera-4285F4.svg" alt="Browser: Chrome, Brave, Edge, Opera">
 </p>
 
 There are hundreds of tools that block, hide, or filter social media. IntentKeeper is the only one that tells you *why* content is designed to manipulate you - and lets you decide what to do with it.
@@ -78,7 +79,11 @@ Don't have Ollama yet? [Install it here](https://ollama.com) - it runs entirely 
 
 ### Part 2 - Extension
 
-1. Open Chrome or Brave and go to `chrome://extensions` (Chrome) or `brave://extensions` (Brave)
+1. Open your browser and go to the extensions page:
+   - Chrome: `chrome://extensions`
+   - Brave: `brave://extensions`
+   - Edge: `edge://extensions`
+   - Opera: `opera://extensions`
 2. Enable **Developer mode** (top right toggle)
 3. Click **Load unpacked** and select the `extension/` folder
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,7 +15,7 @@ This guide explains how to use IntentKeeper day-to-day.
 
 2. **Python 3.10+** installed
 
-3. **Chrome** or Chromium-based browser
+3. **Chrome, Brave, Edge, or Opera** (any Chromium-based browser)
 
 ### Starting the Server
 
@@ -33,11 +33,15 @@ Ollama connection OK (http://localhost:11434)
 
 ### Installing the Extension
 
-1. Open Chrome and go to `chrome://extensions/`
+1. Open your browser and navigate to the extensions page:
+   - Chrome: `chrome://extensions`
+   - Brave: `brave://extensions`
+   - Edge: `edge://extensions`
+   - Opera: `opera://extensions`
 2. Enable **Developer mode** (toggle in top-right)
 3. Click **Load unpacked**
-4. Select the `extension/` folder from the IntentKeeper directory
-5. The IntentKeeper shield icon appears in your toolbar
+4. Select the `extension/` folder from the intentKeeper directory
+5. The intentKeeper icon appears in your toolbar
 
 ### Verify It Works
 
@@ -48,7 +52,7 @@ Ollama connection OK (http://localhost:11434)
 
 ## The Extension Popup
 
-Click the shield icon in your Chrome toolbar to access settings.
+Click the intentKeeper icon in your browser toolbar to access settings.
 
 ### Connection Status
 


### PR DESCRIPTION
## Changes

**README.md**
- Correct name casing: `IntentKeeper` → `intentKeeper` (header + alt text)
- Add browser support badge: Chrome | Brave | Edge | Opera
- Expand Part 2 install instructions to list all four browsers with their extension URLs

**docs/usage.md**
- Prerequisites: "Chrome or Chromium-based browser" → explicit list of all four
- Install steps: expanded to cover all four browsers
- Remove stale "shield icon" reference (replaced with actual logo in popup rebrand)

All four browsers (Chrome, Brave, Edge, Opera) run Chromium and support Manifest V3 - no code changes needed, just the docs were missing.