### PR TITLE
docs: organise README badges into three rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,20 @@
 <p align="center"><strong>A digital bodyguard for your mind.</strong></p>
 
 <p align="center">
+  <!-- Project -->
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <img src="https://img.shields.io/badge/version-0.4.0-green.svg" alt="Version: 0.4.0">
-  <img src="https://img.shields.io/badge/python-3.10%2B-blue.svg" alt="Python: 3.10+">
+  <img src="https://img.shields.io/badge/accuracy-98%25-brightgreen.svg" alt="Accuracy: 98%">
+</p>
+<p align="center">
+  <!-- Platforms -->
   <img src="https://img.shields.io/badge/platform-Twitter%2FX-1DA1F2.svg" alt="Platform: Twitter/X">
   <img src="https://img.shields.io/badge/platform-YouTube-FF0000.svg" alt="Platform: YouTube">
   <img src="https://img.shields.io/badge/platform-Reddit-FF4500.svg" alt="Platform: Reddit">
-  <img src="https://img.shields.io/badge/accuracy-98%25-brightgreen.svg" alt="Accuracy: 98%">
+</p>
+<p align="center">
+  <!-- Tech -->
+  <img src="https://img.shields.io/badge/python-3.10%2B-blue.svg" alt="Python: 3.10+">
   <img src="https://img.shields.io/badge/local--first-Ollama-orange.svg" alt="Local-First: Ollama">
   <img src="https://img.shields.io/badge/browser-Chrome%20%7C%20Brave%20%7C%20Edge%20%7C%20Opera-4285F4.svg" alt="Browser: Chrome, Brave, Edge, Opera">
 </p>


### PR DESCRIPTION
Groups the badges by concern - project (license, version, accuracy), platforms (Twitter/X, YouTube, Reddit), and tech (Python, Ollama, browsers) - instead of one unsorted line.