### PR TITLE
docs: rewrite usage.md

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,23 +1,32 @@
-# Usage Guide
+# intentKeeper - Usage
 
-This guide explains how to use IntentKeeper day-to-day.
+## Setup
 
-## Getting Started
+### What you need
 
-### Prerequisites
+- **Ollama** running locally - [install it here](https://ollama.com)
+- **Python 3.10+**
+- Chrome, Brave, Edge, or Opera
 
-1. **Ollama** installed and running with a model:
-   ```bash
-   # Install Ollama (https://ollama.ai)
-   ollama pull mistral:7b-instruct
-   ollama serve
-   ```
+Any model that runs on Ollama works. Smaller models are faster; larger ones are more accurate:
 
-2. **Python 3.10+** installed
+| Model | Speed | Accuracy |
+|-------|-------|----------|
+| `qwen2.5:3b-instruct` | ~1-3s | Good |
+| `mistral:7b-instruct` | ~3-8s | Better |
+| `llama3.2` or similar | varies | Depends on model |
 
-3. **Chrome, Brave, Edge, or Opera** (any Chromium-based browser)
+Pull whichever you want and set it in `.env`:
 
-### Starting the Server
+```bash
+ollama pull qwen2.5:3b-instruct
+```
+
+```
+OLLAMA_MODEL=qwen2.5:3b-instruct
+```
+
+### Start the server
 
 ```bash
 cd intentKeeper
@@ -25,226 +34,83 @@ pip install -e .
 intentkeeper-server
 ```
 
-The server runs at `http://localhost:8420`. You should see:
-```
-Starting IntentKeeper server on 127.0.0.1:8420
-Ollama connection OK (http://localhost:11434)
-```
+Runs at `http://localhost:8420`. The server needs to stay running while you browse.
 
-### Installing the Extension
+### Load the extension
 
-1. Open your browser and navigate to the extensions page:
+1. Go to your browser's extensions page:
    - Chrome: `chrome://extensions`
    - Brave: `brave://extensions`
    - Edge: `edge://extensions`
    - Opera: `opera://extensions`
-2. Enable **Developer mode** (toggle in top-right)
-3. Click **Load unpacked**
-4. Select the `extension/` folder from the intentKeeper directory
-5. The intentKeeper icon appears in your toolbar
-
-### Verify It Works
-
-1. Visit [twitter.com](https://twitter.com) or [x.com](https://x.com)
-2. Scroll through your feed
-3. Look for intent labels, blurred content, or hidden posts
-4. Click the toolbar icon to check connection status
-
-## The Extension Popup
-
-Click the intentKeeper icon in your browser toolbar to access settings.
-
-### Connection Status
-
-At the top, you'll see the connection indicator:
-- **Green dot**: Server connected, Ollama running
-- **Red dot**: Server unreachable (check if `intentkeeper-server` is running)
-
-### Settings
-
-| Setting | Default | What It Does |
-|---------|---------|--------------|
-| **Enable filtering** | On | Master toggle for all classification |
-| **Show intent tags** | On | Display labels on detected content |
-| **Blur ragebait** | On | Blur high-manipulation content |
-| **Hide engagement bait** | On | Collapse empty interaction requests |
-
-### Sensitivity Slider
-
-The sensitivity slider (30%-90%) controls the **manipulation threshold**:
-- **30% (Strict)**: Flags more content, more false positives
-- **60% (Default)**: Balanced filtering
-- **90% (Relaxed)**: Only flags high-confidence manipulation
-
-The threshold is compared against the `manipulation_score` (intent weight x confidence). Content below the threshold passes through.
-
-## What You'll See
-
-### Blurred Content (Ragebait)
-
-High-manipulation content appears blurred with an overlay:
-```
-┌─────────────────────────────────────────┐
-│ ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │
-│ ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │
-│    Ragebait detected -click to reveal   │
-│              [Show anyway]               │
-└─────────────────────────────────────────┘
-```
-
-Click **Show anyway** to reveal the content. The blur is removed and you can read normally.
-
-### Tagged Content (Fearmongering, Hype, Divisive)
-
-Lower-manipulation content gets a small label:
-```
-[Fear-mongering] The original tweet text is fully
-visible with a small badge at the top.
-```
-
-Hover over the tag to see the confidence percentage.
-
-### Hidden Content (Engagement Bait)
-
-Empty interaction requests are collapsed:
-```
-▶ Hidden: Engagement Bait [Show]
-```
-
-Click **Show** to expand.
-
-### Passed Content (Genuine, Neutral)
-
-Genuine and neutral content displays normally with an intent tag (when tags are enabled), so you can always see that classification is working.
-
-## Intent Categories
-
-| Intent | What It Detects | Visual Treatment |
-|--------|----------------|------------------|
-| **Ragebait** | Content designed to provoke anger or outrage | Blur + reveal button |
-| **Fearmongering** | Exaggerated threats, doom language | Tag label |
-| **Hype** | Manufactured urgency, FOMO triggers | Tag label |
-| **Engagement Bait** | "Reply with your X!", empty interactions | Collapsed/hidden |
-| **Divisive** | Us-vs-them framing, tribal triggers | Tag label |
-| **Genuine** | Authentic insight, honest perspective | Pass (no change) |
-| **Neutral** | Informational, no manipulation | Pass (no change) |
-
-## How Classification Works
-
-IntentKeeper focuses on **how** content is framed, not the topic:
-
-- A political post with nuanced analysis → **genuine**
-- A political post with inflammatory language → **ragebait**
-- A health tip sharing personal experience → **genuine**
-- A health warning using scare tactics → **fearmongering**
-
-The same topic can be classified differently based on its framing and intent.
-
-## Troubleshooting
-
-### Extension shows "Disconnected"
-
-1. Check if the server is running:
-   ```bash
-   curl http://localhost:8420/health
-   ```
-2. If not, start it:
-   ```bash
-   intentkeeper-server
-   ```
-
-### Ollama not connected
-
-1. Check if Ollama is running:
-   ```bash
-   ollama list
-   ```
-2. If not, start it:
-   ```bash
-   ollama serve
-   ```
-3. Verify your model is downloaded:
-   ```bash
-   ollama pull mistral:7b-instruct
-   ```
-
-### No content being classified
-
-1. Check the extension is enabled (popup toggle)
-2. Make sure you're on twitter.com or x.com
-3. Check the browser console for errors (`F12` → Console)
-4. Very short tweets (< 20 characters) are skipped
-
-### Classification is slow
-
-Classification speed depends on your hardware and model:
-- **Small models** (3B): ~1-3 seconds per tweet
-- **Medium models** (7B): ~3-8 seconds
-- **Large models** (13B+): ~10+ seconds
-
-Consider using a smaller model for faster classification:
-```bash
-# In .env
-OLLAMA_MODEL=qwen2.5:3b-instruct  # ~1-3s per tweet
-# or keep the default for better accuracy:
-OLLAMA_MODEL=mistral:7b-instruct  # ~3-8s per tweet
-```
-
-### Too many false positives
-
-Increase the sensitivity threshold (popup slider toward 90%). This reduces false positives but may miss some manipulation.
-
-### Too much content getting through
-
-Decrease the sensitivity threshold (popup slider toward 30%). This catches more manipulation but increases false positives.
-
-## Tips
-
-1. **Start with defaults.** The 60% threshold is a good balance for most users.
-
-2. **Adjust per your tolerance.** If you prefer to see everything and just want labels, turn off blur/hide and keep tags on.
-
-3. **The server must be running.** IntentKeeper needs the local server. If it stops, content just passes through (fail-open design).
-
-4. **Check classifications you disagree with.** The reasoning field (visible in console/API) explains why content was classified a certain way. Use it to calibrate your trust.
-
-5. **Smaller models = faster.** If speed matters more than accuracy, use a 3B model. If accuracy matters more, use 7B+.
-
-## API Reference
-
-The server exposes a REST API. Useful for debugging or building integrations.
-
-### Classify Content
-
-```bash
-curl -X POST http://localhost:8420/classify \
-  -H "Content-Type: application/json" \
-  -d '{"content": "This is EXACTLY why I hate them. Every. Single. Time."}'
-```
-
-Response:
-```json
-{
-  "intent": "ragebait",
-  "confidence": 0.85,
-  "reasoning": "Inflammatory language with absolutist framing",
-  "action": "blur",
-  "manipulation_score": 0.765
-}
-```
-
-### Health Check
-
-```bash
-curl http://localhost:8420/health
-```
-
-### Get Intent Definitions
-
-```bash
-curl http://localhost:8420/intents
-```
+2. Enable **Developer mode**
+3. Click **Load unpacked** and select the `extension/` folder
 
 ---
 
-*"The content isn't the problem. The intent behind it is."*
+## The popup
+
+Click the intentKeeper icon in your toolbar.
+
+**Header** - the master on/off toggle is in the top-right of the header. Turning this off disables all filtering.
+
+**Connection status** - green dot means the server and Ollama are reachable. Red means the server is unreachable (check that `intentkeeper-server` is running).
+
+**Display settings:**
+
+| Toggle | What it does |
+|--------|--------------|
+| Show intent tags | Labels classified content inline |
+| Blur ragebait | Blurs high-manipulation content |
+| Hide engagement bait | Collapses empty interaction requests |
+
+**Sensitivity** - the slider (30-90%) sets the confidence threshold. Lower = catches more, higher = fewer false positives. 60% is the default.
+
+**Intent filters** - per-intent toggles. Turn off an intent to let it pass through with no treatment, even if the classifier detects it.
+
+---
+
+## The page badge
+
+When you open a supported site, a small badge appears in the **bottom-right corner** of the page. It shows:
+
+- **intentKeeper · scanning...** while classifying content on load
+- **intentKeeper · N classified** once done (fades after a few seconds)
+- **intentKeeper · N found, 0 classified** in orange if content was detected but the API call failed
+
+If the server is unreachable, the badge shows in red.
+
+---
+
+## What classification looks like
+
+**Blurred (ragebait)** - content is blurred with a "Show anyway" button. Click to reveal.
+
+**Tagged (fearmongering, hype, divisive)** - content is fully visible with a small label above it. Hover for confidence score.
+
+**Hidden (engagement bait)** - collapsed to a single line with a "Show" link.
+
+**Genuine / neutral** - passes through unchanged (tag still appears if "Show intent tags" is on).
+
+---
+
+## Troubleshooting
+
+**Extension shows disconnected**
+```bash
+curl http://localhost:8420/health
+```
+If that fails, start the server: `intentkeeper-server`
+
+**Nothing being classified**
+- Check the master toggle in the popup header is on
+- Check you're on a supported site (Twitter/X, YouTube, Reddit)
+- Open the browser console (`F12` → Console) and look for errors
+
+**Classification seems off**
+- Adjust the sensitivity slider
+- Use a larger model for better accuracy
+- Check the per-intent filters - an intent might be toggled off
+
+**Server keeps stopping**
+The server is a standard Python process. Run it in a terminal you keep open, or use a tool like `screen` or `tmux` to keep it alive.


### PR DESCRIPTION
- Removed 200 lines of padding, ASCII art diagrams, dramatic quotes
- Model selection: shows a comparison table, not a single hardcoded example
- Page badge: new section documenting the bottom-right scanning indicator
- Popup: documents the master toggle in the header, intent filter toggles (Phase 6.1)
- Structured in clear sections with horizontal rules: setup, popup, page badge, what classification looks like, troubleshooting
- Troubleshooting is short and direct, not a wall of steps