### PR TITLE
feat: Phase 6 complete - confidence disclosure, corrections, allowlist

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -223,39 +223,39 @@
 - [x] Kill switch sits between master enable and action settings; persisted in chrome.storage.local
 - [x] `intentEnabled` map in DEFAULT_SETTINGS; classifier reads it before applying any treatment
 
-### 6.2 Allowlist/Blocklist
-- [ ] Allowlist specific accounts (never filter)
-- [ ] Blocklist specific accounts (always filter)
-- [ ] Import/export lists
+### 6.2 Allowlist ✅ DONE
+**Note**: Blocklist deferred - filtering by source not content conflicts with the "intent over topic" principle (classifying based on who said it, not what was said). Allowlist = user sovereignty; blocklist = editorial stance. Only allowlist implemented.
+
+- [x] Optional `extractAuthor()` method on platform adapters (Twitter, Reddit) - returns lowercase handle/username
+- [x] Allowlist stored in `chrome.storage.local` under `ik_allowlist` as array of bare handles
+- [x] In-memory `Set` in classifier.js for O(1) lookup per item in `processItems()`
+- [x] `onChanged` listener keeps in-memory Set hot when popup updates storage
+- [x] Items from allowlisted authors get `data-intentkeeper-processed="allowed"` - skipped silently
+- [x] Popup "Trusted Accounts" section: add by typing @handle or u/username (prefix stripped on save), remove per-entry
+- [x] YouTube skipped - channel handle format differs from Twitter/Reddit handle pattern; weaker use case
 
 ### 6.3 Custom Intents
 - [ ] User-defined intent categories
 - [ ] Custom indicators and examples
 - [ ] Community-shared intent packs
 
-### 6.4 Confidence Disclosure 🔜 PLANNED
-**Problem**: The extension silently applies labels with no indication of how confident the classifier is. Users have no way to distinguish "99% sure this is ragebait" from "51% sure" - both look identical. This erodes trust when the label feels wrong.
+### 6.4 Confidence Disclosure ✅ DONE
+- [x] Low confidence (<0.65): muted label + "?" suffix + `.intentkeeper-tag--uncertain` class
+- [x] High confidence (>0.85): standard treatment
+- [x] Tooltip: "Classified as ragebait (confidence: 72%)"
+- [x] Blur overlay: low-confidence note rendered inline
+- [x] `CONFIDENCE_LOW` / `CONFIDENCE_HIGH` constants in classifier.js
 
-**Implementation**:
-- [ ] Surface `confidence` score from `/classify` response in the visual treatment
-- [ ] Low confidence (<0.65): add a subtle "?" indicator or muted label color to signal uncertainty
-- [ ] High confidence (>0.85): standard treatment as now
-- [ ] Tooltip on hover: "Classified as ragebait (confidence: 72%)"
-- [ ] No server changes required - `confidence` is already in the API response
+### 6.5 User Override & Local Corrections ✅ DONE
+**Philosophy**: Corrections stored locally only in `chrome.storage.local`. Nothing leaves the device.
 
-### 6.5 User Override & Local Corrections 🔜 PLANNED
-**Problem**: When the classifier gets it wrong, users have no recourse. And "wrong" is personal - what feels like ragebait to one person is legitimate political speech to another. The only way to calibrate a local tool correctly is to let the user teach it.
-
-**Philosophy note**: Corrections are stored locally only, in `chrome.storage.local`. Nothing leaves the device. No upload mechanism, no opt-in telemetry. The data belongs to the user and improves only their experience.
-
-**Implementation**:
-- [ ] Add a one-click correction button on each labeled item ("Not [intent] - correct this")
-- [ ] Show a small dropdown: what was it actually? (ragebait / fearmongering / hype / genuine / other)
-- [ ] Store correction in `chrome.storage.local` as `corrections[]` with: original content hash, assigned intent, corrected intent, timestamp
-- [ ] At classification time, retrieve the 3-5 most recent corrections and inject them into the LLM prompt as additional few-shot examples: "Note: for content like this, you previously labeled it [correct] not [wrong]"
-- [ ] Cap corrections at 100 entries (LRU eviction - oldest dropped first)
-- [ ] Add "My Corrections" section in popup: count of corrections made, option to clear all
-- [ ] Note: IndexedDB (Phase 7) will eventually replace `chrome.storage.local` for corrections - design the storage key format with that migration in mind
+- [x] Pencil button (✏️) on each tag - hover to reveal, click to open correction picker
+- [x] Correction picker dropdown: all intents except the current one + Cancel
+- [x] `saveCorrection(snippet, originalIntent, correctedIntent)` - stores to `ik_corrections`, LRU cap at 100
+- [x] `loadCorrectionsForPrompt()` in background.js - loads 5 most recent corrections
+- [x] Corrections injected into LLM prompt as personalized few-shot examples per item in batch
+- [x] Tag updates to strikethrough state after correction
+- [x] Popup "My Corrections" section: count + Clear all button
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,9 +11,10 @@ This document provides a visual overview of IntentKeeper's architecture. For det
 │  ┌──────────────────────────────────────────────────────────────┐   │
 │  │              Browser (Chrome / Brave)                        │   │
 │  │  ┌─────────────┐                                             │   │
-│  │  │  Extension   │ ◄── Intercepts content from Twitter/X,      │   │
-│  │  │              │     Reddit (shreddit, new, old variants)    │   │
-│  │  │  content.js  │                                             │   │
+│  │  │  Extension   │ ◄── Intercepts content from:               │   │
+│  │  │              │     Twitter/X (tweets, replies)            │   │
+│  │  │  classifier  │     Reddit (shreddit, new, old variants)   │   │
+│  │  │  .js (core)  │     YouTube (feed cards, comments)         │   │
 │  │  └──────┬──────┘                                              │   │
 │  │         │ POST /classify                                      │   │
 │  └─────────┼────────────────────────────────────────────────────┘   │
@@ -47,26 +48,44 @@ This document provides a visual overview of IntentKeeper's architecture. For det
 ## Classification Flow
 
 ```
-Content Intercepted (tweet text)
+Content Intercepted (tweet / post / comment)
     │
     ▼
 ┌─────────────────────────────────────────────┐
 │  1. LENGTH CHECK                            │
-│     < 20 characters → neutral (skip LLM)    │
+│     < 20 characters → mark "skipped"       │
+│     empty string → leave unmarked          │
+│       (element still loading, retry next   │
+│        observer pass)                       │
 └─────────────────────────────────────────────┘
     │ Pass
     ▼
 ┌─────────────────────────────────────────────┐
-│  2. BUILD PROMPT                            │
+│  2. ALLOWLIST CHECK (Phase 6.2)             │
+│     adapter.extractAuthor() if defined      │
+│     → Twitter: @handle (bare, lowercase)    │
+│     → Reddit: u/username (bare, lowercase)  │
+│     If author in chrome.storage ik_allowlist│
+│     → mark "allowed", skip classification  │
+│     In-memory Set for O(1) lookup           │
+└─────────────────────────────────────────────┘
+    │ Not allowlisted
+    ▼
+┌─────────────────────────────────────────────┐
+│  3. BUILD PROMPT                            │
 │     Intent descriptions from YAML           │
-│     + Few-shot examples (up to 5)           │
+│     + User corrections (Phase 6.5):         │
+│       5 most recent corrections from        │
+│       chrome.storage ik_corrections,        │
+│       injected as personalised few-shot     │
+│       examples before the content block     │
 │     + Classification rules                  │
-│     + Content to classify                   │
+│     + Content to classify (truncated 5000c) │
 └─────────────────────────────────────────────┘
     │
     ▼
 ┌─────────────────────────────────────────────┐
-│  3. OLLAMA API CALL                         │
+│  4. OLLAMA API CALL                         │
 │     Temperature: 0.1 (deterministic)        │
 │     Max tokens: 150                         │
 │     Timeout: 30 seconds                     │
@@ -74,7 +93,7 @@ Content Intercepted (tweet text)
     │
     ▼
 ┌─────────────────────────────────────────────┐
-│  4. PARSE JSON RESPONSE                     │
+│  5. PARSE JSON RESPONSE                     │
 │     Extract: intent, confidence, reasoning  │
 │     Validate intent against known categories│
 │     Fallback to neutral on parse failure    │
@@ -82,7 +101,7 @@ Content Intercepted (tweet text)
     │
     ▼
 ┌─────────────────────────────────────────────┐
-│  5. CALCULATE ACTION                        │
+│  6. CALCULATE ACTION                        │
 │     Look up action from intents.yaml        │
 │     manipulation_score = weight × confidence│
 │     Apply user threshold                    │
@@ -90,13 +109,16 @@ Content Intercepted (tweet text)
     │
     ▼
 ┌─────────────────────────────────────────────┐
-│  6. RETURN ClassificationResult             │
+│  7. RETURN ClassificationResult             │
 │     {intent, confidence, reasoning,         │
 │      action, manipulation_score}            │
 └─────────────────────────────────────────────┘
     │
     ▼
-Visual Treatment Applied (content.js)
+Visual Treatment Applied (classifier.js)
+    - confidence < 0.65 → muted label + "?"  (Phase 6.4)
+    - confidence shown in tooltip + blur note (Phase 6.4)
+    - pencil button → correction picker      (Phase 6.5)
 ```
 
 ## Component Relationships
@@ -109,39 +131,57 @@ Visual Treatment Applied (content.js)
 │  │core/classifier.js│  │ background.js│  │  popup/popup.js  │  │
 │  │ (IntentKeeperCore│  │              │  │                  │  │
 │  │ - DOM observation│  │ - Settings   │  │ - Toggle UI      │  │
-│  │ - API calls      │  │ - Health poll│  │ - Sliders        │  │
+│  │ - Batch API calls│  │ - Health poll│  │ - Sliders        │  │
 │  │ - CSS treatments │  │ - Badge icon │  │ - Status display │  │
-│  │ - PNA middleware │  │ - PNA proxy  │  │                  │  │
+│  │ - Allowlist Set  │  │ - PNA proxy  │  │ - Trusted Accts  │  │
+│  │   (Phase 6.2)    │  │ - Corrections│  │   add/remove     │  │
+│  │ - Confidence UI  │  │   few-shot   │  │ - My Corrections │  │
+│  │   (Phase 6.4)    │  │   injection  │  │   count + clear  │  │
+│  │ - Correction     │  │   (6.5)      │  │                  │  │
+│  │   picker (6.5)   │  │              │  │                  │  │
 │  └────────┬─────────┘  └──────────────┘  └──────────────────┘  │
 │           │ uses platform adapters                               │
 │  ┌────────┴──────────────────────────────────────────────────┐  │
 │  │  Platform Adapters (extension/platforms/)                  │  │
-│  │  twitter.js - Twitter/X DOM (tweets)                       │  │
-│  │  reddit.js  - Reddit DOM (shreddit, new reddit, old reddit)│  │
+│  │  twitter.js - Twitter/X DOM; extractAuthor() → @handle    │  │
+│  │  reddit.js  - Reddit DOM (shreddit, new, old);            │  │
+│  │               extractAuthor() → u/username                 │  │
+│  │  youtube.js - YouTube DOM (no extractAuthor - not needed) │  │
 │  └────────┬──────────────────────────────────────────────────┘  │
 │           │                                                      │
-└───────────┼──────────────────────────────────────────────────────┘
-            │ HTTP (localhost:8420)
-            ▼
+│  ┌────────┴──────────────────────────────────────────────────┐  │
+│  │  chrome.storage.local                                      │  │
+│  │  intentkeeper_settings  - all user toggles/thresholds      │  │
+│  │  ik_allowlist[]         - trusted account handles (6.2)    │  │
+│  │  ik_corrections[]       - label corrections, LRU-100 (6.5) │  │
+│  └────────────────────────────────────────────────────────────┘  │
+│                                                                 │
+└───────────────────────────────────┬────────────────────────────┘
+                                    │ HTTP (localhost:8420)
+                                    ▼
 ┌────────────────────────────────────────────────────────────────┐
 │                    FastAPI Server (api.py)                      │
 │                                                                 │
 │   Endpoints:                                                    │
-│   POST /classify         -Single classification               │
-│   POST /classify/batch   -Batch (max 50)                      │
-│   GET  /health           -Server + Ollama status              │
-│   GET  /intents          -Current definitions                 │
+│   POST /classify         - Single classification               │
+│   POST /classify/batch   - Batch (max 50)                      │
+│   GET  /health           - Server + Ollama status              │
+│   GET  /intents          - Current definitions                 │
+│                                                                 │
+│   Request body includes user_corrections[] (Phase 6.5)         │
+│   Pydantic-validated before passing to classifier              │
 └───────────────────────────┬────────────────────────────────────┘
                             │ uses
                             ▼
 ┌────────────────────────────────────────────────────────────────┐
 │                  IntentClassifier (classifier.py)               │
 │                                                                 │
-│   - Loads intents from YAML                                    │
-│   - Builds classification prompts                              │
-│   - Calls Ollama API                                           │
-│   - Parses JSON responses                                      │
-│   - Fail-open error handling                                   │
+│   - Loads intents from YAML                                     │
+│   - Builds classification prompts with user corrections         │
+│     injected as personalised few-shot examples (Phase 6.5)     │
+│   - Calls Ollama API                                            │
+│   - Parses JSON responses                                       │
+│   - Fail-open error handling                                    │
 └───────────────────────────┬────────────────────────────────────┘
                             │ reads
                             ▼
@@ -199,13 +239,17 @@ Visual Treatment Applied (content.js)
 │   ┌─────────────────────────────────────────────────┐           │
 │   │ ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │           │
 │   │ ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │           │
-│   │          ⚠ Ragebait detected -click to reveal   │           │
+│   │   🛡️ Ragebait  [Low confidence (61%)]  ✏️       │           │
+│   │   Designed to provoke outrage response          │           │
+│   │          [Show anyway]                          │           │
 │   └─────────────────────────────────────────────────┘           │
 │                                                                  │
 │   TAG (fearmongering, hype, divisive)                            │
 │   ┌─────────────────────────────────────────────────┐           │
-│   │ [fearmongering] Original content visible here    │           │
-│   │ with a small label badge in the corner.          │           │
+│   │ 🛡️ Fearmongering ✏️  Original content visible   │           │
+│   │ tooltip: "Classified as fearmongering (87%)"    │           │
+│   │ low-confidence variant: 🛡️ Fearmongering ? ✏️   │           │
+│   │ (muted colour, italic, tooltip shows %)         │           │
 │   └─────────────────────────────────────────────────┘           │
 │                                                                  │
 │   HIDE (engagement_bait)                                         │
@@ -217,6 +261,17 @@ Visual Treatment Applied (content.js)
 │   ┌─────────────────────────────────────────────────┐           │
 │   │ Content displayed normally, no modification.     │           │
 │   └─────────────────────────────────────────────────┘           │
+│                                                                  │
+│   ALLOWED (Phase 6.2)                                            │
+│   ┌─────────────────────────────────────────────────┐           │
+│   │ Author in allowlist → classification skipped    │           │
+│   │ No tag, no blur. Marked allowed in DOM attr.    │           │
+│   └─────────────────────────────────────────────────┘           │
+│                                                                  │
+│   Confidence thresholds (Phase 6.4):                             │
+│   < 0.65 → muted label, italic, "?" suffix                       │
+│   0.65 - 0.85 → standard treatment                               │
+│   > 0.85 → standard treatment (no indicator needed)              │
 │                                                                  │
 └─────────────────────────────────────────────────────────────────┘
 ```

--- a/extension/core/classifier.js
+++ b/extension/core/classifier.js
@@ -116,16 +116,37 @@ async function loadSettings() {
   }
 }
 
-// React to settings changes without requiring a page reload
+// React to settings/allowlist changes without requiring a page reload
 chrome.storage.onChanged.addListener((changes, area) => {
-  if (area === 'local' && changes.intentkeeper_settings) {
+  if (area !== 'local') return;
+  if (changes.intentkeeper_settings) {
     const newSettings = changes.intentkeeper_settings.newValue;
     if (newSettings) {
       settings = { ...settings, ...newSettings };
       debug.log('Settings updated');
     }
   }
+  if (changes.ik_allowlist) {
+    allowlist = new Set(changes.ik_allowlist.newValue || []);
+    debug.log('Allowlist updated', allowlist.size, 'entries');
+  }
 });
+
+// --- Allowlist (Phase 6.2) ---
+
+const ALLOWLIST_KEY = 'ik_allowlist';
+
+// In-memory Set for O(1) lookup during processItems()
+let allowlist = new Set();
+
+async function loadAllowlist() {
+  try {
+    const stored = await chrome.storage.local.get(ALLOWLIST_KEY);
+    allowlist = new Set(stored[ALLOWLIST_KEY] || []);
+  } catch (e) {
+    debug.log('Failed to load allowlist');
+  }
+}
 
 // --- Corrections (Phase 6.5) ---
 
@@ -450,6 +471,14 @@ async function processItems(adapter) {
           item.setAttribute(PROCESSED_ATTR, 'skipped');
         }
       } else {
+        // Skip classification for allowlisted authors
+        if (adapter.extractAuthor) {
+          const author = adapter.extractAuthor(item);
+          if (author && allowlist.has(author)) {
+            item.setAttribute(PROCESSED_ATTR, 'allowed');
+            continue;
+          }
+        }
         item.classList.add('intentkeeper-classifying');
         foundCount++;
         itemData.push({ item, text, mediaUrls });
@@ -564,6 +593,7 @@ window.IntentKeeperCore = {
     debug.log(`Initializing [${adapter.platform}]...`);
 
     await loadSettings();
+    await loadAllowlist();
 
     if (!settings.enabled) {
       debug.log('Disabled');

--- a/extension/platforms/reddit.js
+++ b/extension/platforms/reddit.js
@@ -280,6 +280,29 @@ const redditAdapter = {
     if (element.dataset.testid === 'comment') return extractNewRedditCommentText(element);
     return extractNewRedditPostText(element);
   },
+
+  /**
+   * Extract the Reddit username of the post/comment author (Phase 6.2).
+   * Returns lowercase username without u/, e.g. "spez", or null if not found.
+   */
+  extractAuthor(element) {
+    // Shreddit
+    const shredditAuthor = element.getAttribute('author');
+    if (shredditAuthor) return shredditAuthor.toLowerCase();
+
+    // New Reddit
+    const authorLink = element.querySelector('[data-testid="comment_author_link"], a[href*="/user/"]');
+    if (authorLink) {
+      const match = authorLink.getAttribute('href').match(/\/user\/([^/]+)/);
+      if (match) return match[1].toLowerCase();
+    }
+
+    // Old Reddit
+    const oldAuthor = element.querySelector('.author');
+    if (oldAuthor) return oldAuthor.textContent.trim().toLowerCase();
+
+    return null;
+  }
 };
 
 if (typeof IntentKeeperCore !== 'undefined') {

--- a/extension/platforms/twitter.js
+++ b/extension/platforms/twitter.js
@@ -185,6 +185,20 @@ const twitterAdapter = {
     }
 
     return parts.join(' | ');
+  },
+
+  /**
+   * Extract the @handle of the tweet author (Phase 6.2 allowlist/blocklist).
+   * Returns lowercase handle without @, e.g. "nytimes", or null if not found.
+   */
+  extractAuthor(tweetElement) {
+    const userNameEl = tweetElement.querySelector('[data-testid="User-Name"]');
+    if (!userNameEl) return null;
+    // The @handle appears as a link with href="/username" inside User-Name
+    const link = userNameEl.querySelector('a[href^="/"]');
+    if (!link) return null;
+    const handle = link.getAttribute('href').replace('/', '').split('/')[0].toLowerCase();
+    return handle || null;
   }
 };
 

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -331,6 +331,26 @@
     </div>
   </div>
 
+  <hr class="divider">
+
+  <div class="section-label">Trusted Accounts</div>
+  <div class="group">
+    <div class="setting" style="gap:6px;padding-bottom:8px;">
+      <input type="text" id="allowlist-input" placeholder="@handle or u/username" style="
+        flex:1;background:#1a1a2a;border:1px solid #2a2a3e;border-radius:5px;
+        color:#c0c0d8;font-size:11px;padding:4px 8px;outline:none;">
+      <button id="allowlist-add" style="
+        background:#1e1e30;border:1px solid #333350;border-radius:5px;
+        color:#4ade80;cursor:pointer;font-size:10px;padding:4px 10px;white-space:nowrap;">
+        Add
+      </button>
+    </div>
+    <div id="allowlist-list" style="display:flex;flex-direction:column;gap:2px;"></div>
+    <div id="allowlist-empty" style="font-size:10px;color:#444458;padding:2px 0 4px;">
+      Content from trusted accounts skips classification
+    </div>
+  </div>
+
   <div class="footer">
     <span>Local-first &mdash; no data leaves your device</span>
     <a href="https://github.com/Olawoyin007/intentKeeper" target="_blank">GitHub</a>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -132,7 +132,64 @@ document.getElementById('clear-corrections').addEventListener('click', async () 
   await loadCorrectionsCount();
 });
 
+// --- Allowlist (Phase 6.2) ---
+
+async function loadAllowlist() {
+  const stored = await chrome.storage.local.get('ik_allowlist');
+  const list = stored.ik_allowlist || [];
+  const listEl = document.getElementById('allowlist-list');
+  const emptyEl = document.getElementById('allowlist-empty');
+  listEl.innerHTML = '';
+
+  if (list.length === 0) {
+    emptyEl.style.display = '';
+    return;
+  }
+  emptyEl.style.display = 'none';
+
+  for (const handle of list) {
+    const row = document.createElement('div');
+    row.style.cssText = 'display:flex;justify-content:space-between;align-items:center;padding:3px 0;';
+    row.innerHTML = `
+      <span style="font-size:11px;color:#9090b0;">${handle}</span>
+      <button data-handle="${handle}" style="
+        background:none;border:none;color:#555568;cursor:pointer;font-size:10px;padding:2px 4px;">
+        Remove
+      </button>`;
+    row.querySelector('button').addEventListener('click', async (e) => {
+      const h = e.currentTarget.dataset.handle;
+      const s = await chrome.storage.local.get('ik_allowlist');
+      const updated = (s.ik_allowlist || []).filter(x => x !== h);
+      await chrome.storage.local.set({ ik_allowlist: updated });
+      await loadAllowlist();
+    });
+    listEl.appendChild(row);
+  }
+}
+
+document.getElementById('allowlist-add').addEventListener('click', async () => {
+  const input = document.getElementById('allowlist-input');
+  const raw = input.value.trim().toLowerCase();
+  if (!raw) return;
+  // Normalize: strip leading @ or u/
+  const handle = raw.replace(/^@/, '').replace(/^u\//, '');
+  if (!handle) return;
+  const stored = await chrome.storage.local.get('ik_allowlist');
+  const list = stored.ik_allowlist || [];
+  if (!list.includes(handle)) {
+    list.push(handle);
+    await chrome.storage.local.set({ ik_allowlist: list });
+  }
+  input.value = '';
+  await loadAllowlist();
+});
+
+document.getElementById('allowlist-input').addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') document.getElementById('allowlist-add').click();
+});
+
 // Initialize
 loadSettings();
 checkHealth();
 loadCorrectionsCount();
+loadAllowlist();


### PR DESCRIPTION
## Summary

Completes Phase 6 (User-Configurable Sensitivity) with three sub-phases:

**Phase 6.4 - Confidence Disclosure**
- Low-confidence labels (<65%) rendered muted + italic with `?` suffix
- Tooltip on every tag: "Classified as ragebait (confidence: 72%)"
- Blur overlay shows inline low-confidence note

**Phase 6.5 - User Corrections (local only)**
- Pencil button on each tag (hover to reveal); opens correction picker
- Corrections stored in `chrome.storage.local` under `ik_corrections` (LRU-100)
- Injected as personalised few-shot examples into LLM prompt at inference time
- Nothing leaves the device
- Popup: My Corrections count + Clear all

**Phase 6.2 - Allowlist (blocklist deferred)**
- Blocklist deferred: filtering by source conflicts with "intent over topic" manifesto
- `extractAuthor()` on Twitter (bare @handle) and Reddit (shreddit/new/old variants)
- In-memory `Set` in classifier.js; `onChanged` listener keeps it hot
- `processItems()` checks allowlist before queuing - marks `allowed`, skips silently
- Popup: Trusted Accounts section with add (normalises @/u/ prefix) and per-entry remove
- `docs/architecture.md` updated: classification flow, component diagram, treatments

## Test plan
- [ ] Add a Twitter handle to Trusted Accounts; verify tweets from that account get no tag/blur
- [ ] Add a Reddit username; verify their comments pass through unclassified
- [ ] Remove an account from the list; verify classification resumes
- [ ] Correct a misclassified tag; verify pencil appears on hover, picker shows all other intents
- [ ] Check popup My Corrections count increments; Clear resets to 0
- [ ] Low-confidence label shows `?` suffix and muted styling; high-confidence shows standard