### PR TITLE
release: v0.5.0 - User Control & Platform Reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 All notable changes to IntentKeeper are documented here.
 
+## v0.5.0 (2026-04-26) - User Control & Platform Reliability
+
+**"You decide what stays. The extension gets out of the way."**
+
+### User-Configurable Sensitivity (Phase 6)
+
+**Per-Intent Kill Switches (Phase 6.1)**
+- Every intent (ragebait, engagement_bait, fearmongering, divisive, hype) now has its own toggle in the popup. Disable any intent you don't want filtered without touching the others. Settings persist via `chrome.storage.local`.
+
+**Trusted Accounts / Allowlist (Phase 6.2)**
+- Add accounts you trust to an allowlist in the popup. Their content bypasses classification entirely, regardless of what the model would have said. Handles `@username` and `u/username` prefix normalization. In-memory `Set` for O(1) per-item lookup.
+
+**Confidence Disclosure (Phase 6.4)**
+- Low-confidence classifications (below threshold) are now shown with a "?" indicator so you know when the model is uncertain. Confidence score exposed in the UI alongside the intent label.
+
+**User Corrections (Phase 6.5)**
+- Wrong classification? Click the pencil icon to correct it. Corrections are stored locally and injected as few-shot examples into subsequent classifier prompts, improving accuracy for your specific feed over time.
+
+### Platform Reliability
+
+**YouTube SPA Navigation**
+- YouTube's single-page app navigation (pushState/popstate) now correctly triggers re-classification when navigating between videos without a full page reload. Observer hardened against edge cases.
+
+**YouTube Lazy-Load Fix**
+- Feed items that load after initial page render (infinite scroll) are now correctly classified. Added lazy-load guard that watches for new DOM nodes.
+
+**Reddit SPA Navigation + Comment Context**
+- Reddit's React router navigation handled. Comment context (subreddit, flair) now included in classification text for better accuracy on community-specific content.
+
+**Twitter/Reddit Lazy-Load Guard**
+- Applied the same lazy-load guard to Twitter and Reddit adapters. Fixes missed classifications on scroll.
+
+### UI Rebrand
+- Extension renamed from working title to **intentKeeper** throughout popup, icons, and manifest. New logo. Popup redesigned with cleaner layout, real branding, and collapsible sections.
+
+### Multi-Browser Support
+- **Chrome, Brave, Edge, Opera** all confirmed working. Brave's strict Private Network Access enforcement handled automatically via `PrivateNetworkAccessMiddleware` - no user configuration needed.
+
+### Model Benchmark (new)
+- `scripts/benchmark.py` measures classification accuracy and latency across locally installed Ollama models using the 80-example labeled eval set. Results written to `docs/model-benchmark.md` organized by Min VRAM requirement.
+- Partial results saved after each model; `--resume` picks up from a crash.
+
+### Stats
+- 3 platforms: Twitter/X, YouTube, Reddit
+- 4 browsers: Chrome, Brave, Edge, Opera
+- 98% eval accuracy (78/80) on 80-example labeled set
+- Per-intent kill switches, allowlist, confidence disclosure, user corrections
+
+---
+
 ## v0.4.0 (2026-04-12) - Reddit, Brave & Classification Accuracy
 
 **"Three platforms. 98% accuracy. Works in Brave."**

--- a/README.md
+++ b/README.md
@@ -79,11 +79,21 @@ cp .env.example .env
 intentkeeper-server
 ```
 
-**Ollama powers the classification.** Any model works - `mistral:7b-instruct`, `llama3.2`, `phi3`, whatever you have. Set it in `.env` and the server pulls it automatically on first start if it is not already present:
+**Ollama powers the classification.** Set your model in `.env` and the server pulls it automatically on first start:
 
 ```bash
 OLLAMA_MODEL=your-model-name
 ```
+
+**Recommended models** (benchmarked on the 80-example eval set - see [`docs/model-benchmark.md`](docs/model-benchmark.md)):
+
+| Min VRAM | Model | Accuracy | Latency |
+|:--------:|-------|:--------:|:-------:|
+| 4 GB | `llama3.2:latest` | 98% | 1.5s |
+| 8 GB | `mistral:7b-instruct` | 96% | 0.9s |
+| 8 GB | `llama3.1:8b` | 98% | 1.8s |
+
+`llama3.2` (2 GB) hits the same 98% accuracy ceiling as models 4x its size - the best default for most hardware. `mistral:7b-instruct` is the fastest option if speed matters more than the 2% gap.
 
 Don't have Ollama yet? [Install it here](https://ollama.com) - it runs entirely on your hardware, no cloud required.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -213,7 +213,7 @@
 
 ---
 
-## Phase 6: User-Configurable Sensitivity 🔧 IN PROGRESS
+## Phase 6: User-Configurable Sensitivity ✅ COMPLETE
 
 **Goal**: Let users fine-tune what content is filtered.
 
@@ -431,21 +431,21 @@ Safari requires Apple developer account, Xcode, and wrapping the extension in a 
 
 ---
 
-## Current Status (2026-04-12)
+## Current Status (2026-04-26)
 
-**Completed**: Phase 1 (Core + Twitter/X), Phase 2 (Hardening), Phase 3.1-3.3 + 3.5 (YouTube + platform abstraction), Phase 4 (Reddit - 3 DOM variants: Shreddit, new Reddit, old Reddit), Phase 5.1-5.2 (98% accuracy on 80-example eval, prompt ceiling reached), Phase 8.1 (Chrome, Brave, Edge, Opera all working - PNA middleware for Brave)
+**Completed**: Phase 1 (Core + Twitter/X), Phase 2 (Hardening), Phase 3.1-3.3 + 3.5 (YouTube + platform abstraction), Phase 4 (Reddit - 3 DOM variants), Phase 5.1-5.2 (98% accuracy), Phase 6.1-6.5 (User-Configurable Sensitivity - all subphases complete), Phase 8.1 (Brave PNA middleware) - **v0.5.0 released**
 
-**Prompt ceiling**: The 2 remaining misclassified cases are at the model's training boundary. Fine-tuning (Phase 5.3) would be needed to pass 98%. Prompting cannot resolve them without breaking other cases.
+**Prompt ceiling**: The 2 remaining misclassified cases are at the model's training boundary. Fine-tuning (Phase 5.3) would be needed to pass 98%. Prompting cannot resolve them.
 
-**Next Up**: Phase 6 (User-Configurable Sensitivity) - now that accuracy and platform coverage are solid
+**Next Up**: Phase 7 (Statistics Dashboard) or Phase 8.2 (Firefox support)
 
 **Stats**:
 
-- 98% eval accuracy (78/80, measured 2026-04-09)
+- 98% eval accuracy (78/80)
 - 6 intent categories (ragebait, fearmongering, hype, engagement_bait, divisive, genuine)
 - 3 platforms (Twitter/X, YouTube, Reddit)
-- Chrome, Brave, Edge, and Opera all supported (PNA middleware for Brave)
-- Async pipeline with batch classification and LRU cache
+- 4 browsers: Chrome, Brave, Edge, Opera
+- Per-intent kill switches, allowlist, confidence disclosure, user corrections
 
 ---
 

--- a/docs/benchmark-results.json
+++ b/docs/benchmark-results.json
@@ -1,0 +1,157 @@
+{
+  "qwen2.5:1.5b-instruct": {
+    "accuracy": 0.6125,
+    "correct": 49,
+    "total": 80,
+    "avg_latency_ms": 1979.8436064076668,
+    "per_intent": {
+      "ragebait": 0.3076923076923077,
+      "fearmongering": 0.7,
+      "genuine": 0.8260869565217391,
+      "hype": 0.2727272727272727,
+      "engagement_bait": 0.5,
+      "divisive": 0.9090909090909091
+    }
+  },
+  "gemma:2b-instruct": {
+    "accuracy": 0.4875,
+    "correct": 39,
+    "total": 80,
+    "avg_latency_ms": 1871.2495342755574,
+    "per_intent": {
+      "ragebait": 0.07692307692307693,
+      "fearmongering": 0.6,
+      "genuine": 0.5652173913043478,
+      "hype": 0.18181818181818182,
+      "engagement_bait": 0.6666666666666666,
+      "divisive": 0.8181818181818182
+    }
+  },
+  "qwen2.5:3b-instruct": {
+    "accuracy": 0.8375,
+    "correct": 67,
+    "total": 80,
+    "avg_latency_ms": 1849.2468334254227,
+    "per_intent": {
+      "ragebait": 0.7692307692307693,
+      "fearmongering": 1.0,
+      "genuine": 0.9565217391304348,
+      "hype": 1.0,
+      "engagement_bait": 0.3333333333333333,
+      "divisive": 0.9090909090909091
+    }
+  },
+  "llama3.2:latest": {
+    "accuracy": 0.975,
+    "correct": 78,
+    "total": 80,
+    "avg_latency_ms": 1503.281782776321,
+    "per_intent": {
+      "ragebait": 1.0,
+      "fearmongering": 1.0,
+      "genuine": 1.0,
+      "hype": 1.0,
+      "engagement_bait": 0.9166666666666666,
+      "divisive": 0.9090909090909091
+    }
+  },
+  "phi3.5:latest": {
+    "accuracy": 0.675,
+    "correct": 54,
+    "total": 80,
+    "avg_latency_ms": 1066.030047791719,
+    "per_intent": {
+      "ragebait": 0.23076923076923078,
+      "fearmongering": 0.9,
+      "genuine": 0.5652173913043478,
+      "hype": 0.8181818181818182,
+      "engagement_bait": 0.9166666666666666,
+      "divisive": 0.8181818181818182
+    }
+  },
+  "mistral:7b-instruct": {
+    "accuracy": 0.9625,
+    "correct": 77,
+    "total": 80,
+    "avg_latency_ms": 925.7604030062794,
+    "per_intent": {
+      "ragebait": 0.9230769230769231,
+      "fearmongering": 1.0,
+      "genuine": 1.0,
+      "hype": 1.0,
+      "engagement_bait": 0.8333333333333334,
+      "divisive": 1.0
+    }
+  },
+  "llama3.1:8b": {
+    "accuracy": 0.975,
+    "correct": 78,
+    "total": 80,
+    "avg_latency_ms": 1798.741577846522,
+    "per_intent": {
+      "ragebait": 1.0,
+      "fearmongering": 1.0,
+      "genuine": 1.0,
+      "hype": 1.0,
+      "engagement_bait": 0.8333333333333334,
+      "divisive": 1.0
+    }
+  },
+  "qwen2.5:7b-instruct": {
+    "accuracy": 0.925,
+    "correct": 74,
+    "total": 80,
+    "avg_latency_ms": 1817.9039014896262,
+    "per_intent": {
+      "ragebait": 0.9230769230769231,
+      "fearmongering": 1.0,
+      "genuine": 1.0,
+      "hype": 0.9090909090909091,
+      "engagement_bait": 0.75,
+      "divisive": 0.9090909090909091
+    }
+  },
+  "dolphin-mistral:latest": {
+    "accuracy": 0.925,
+    "correct": 74,
+    "total": 80,
+    "avg_latency_ms": 1063.6046947889554,
+    "per_intent": {
+      "ragebait": 0.6923076923076923,
+      "fearmongering": 1.0,
+      "genuine": 1.0,
+      "hype": 1.0,
+      "engagement_bait": 0.8333333333333334,
+      "divisive": 1.0
+    }
+  },
+  "gemma3:12b": {
+    "accuracy": 0.9625,
+    "correct": 77,
+    "total": 80,
+    "avg_latency_ms": 2873.678991700581,
+    "per_intent": {
+      "ragebait": 0.9230769230769231,
+      "fearmongering": 1.0,
+      "genuine": 0.9130434782608695,
+      "hype": 1.0,
+      "engagement_bait": 1.0,
+      "divisive": 1.0
+    }
+  },
+  "qwen2.5:14b-instruct-q4_K_M": {
+    "accuracy": 0.975,
+    "correct": 78,
+    "total": 80,
+    "avg_latency_ms": 2604.3177752748306,
+    "per_intent": {
+      "ragebait": 1.0,
+      "fearmongering": 1.0,
+      "genuine": 0.9565217391304348,
+      "hype": 0.9090909090909091,
+      "engagement_bait": 1.0,
+      "divisive": 1.0
+    }
+  },
+  "updated_at": "2026-04-26T14:24:59.625804+00:00"
+}

--- a/docs/model-benchmark.md
+++ b/docs/model-benchmark.md
@@ -1,0 +1,56 @@
+# Model Benchmark
+
+Classification accuracy on the 80-example labeled eval set (`eval/test_set.yaml`).
+Higher accuracy = fewer wrong classifications on real social media content.
+
+_Last run: 2026-04-26 14:24 UTC_
+
+---
+
+## Overall Accuracy
+
+| Model | Size | Min VRAM | Accuracy | Avg Latency/item |
+|-------|------|:--------:|:--------:|:----------------:|
+| `llama3.2:latest` | 2.0 GB | 4 GB | **98%** (78/80) | 1.5s |
+| `llama3.1:8b` | 4.9 GB | 8 GB | **98%** (78/80) | 1.8s |
+| `qwen2.5:14b-instruct-q4_K_M` | 9.0 GB | 12 GB | **98%** (78/80) | 2.6s |
+| `mistral:7b-instruct` | 4.4 GB | 8 GB | **96%** (77/80) | 926ms |
+| `gemma3:12b` | 8.1 GB | 12 GB | **96%** (77/80) | 2.9s |
+| `qwen2.5:7b-instruct` | 4.7 GB | 8 GB | **92%** (74/80) | 1.8s |
+| `dolphin-mistral:latest` | 4.1 GB | 8 GB | **92%** (74/80) | 1.1s |
+| `qwen2.5:3b-instruct` | 1.9 GB | 4 GB | **84%** (67/80) | 1.8s |
+| `phi3.5:latest` | 2.2 GB | 4 GB | **68%** (54/80) | 1.1s |
+| `qwen2.5:1.5b-instruct` | 983 MB | CPU / Any | **61%** (49/80) | 2.0s |
+| `gemma:2b-instruct` | 1.6 GB | 4 GB | **49%** (39/80) | 1.9s |
+
+## Per-Intent Accuracy
+
+Accuracy broken down by intent. Low scores highlight where a model struggles.
+
+| Model | divisive | engagement_bait | fearmongering | genuine | hype | ragebait |
+|-------|:---------:|:---------:|:---------:|:---------:|:---------:|:---------:|
+| `llama3.2:latest` | 91% | 92% | 100% | 100% | 100% | 100% |
+| `llama3.1:8b` | 100% | 83% | 100% | 100% | 100% | 100% |
+| `qwen2.5:14b-instruct-q4_K_M` | 100% | 100% | 100% | 96% | 91% | 100% |
+| `mistral:7b-instruct` | 100% | 83% | 100% | 100% | 100% | 92% |
+| `gemma3:12b` | 100% | 100% | 100% | 91% | 100% | 92% |
+| `qwen2.5:7b-instruct` | 91% | 75% | 100% | 100% | 91% | 92% |
+| `dolphin-mistral:latest` | 100% | 83% | 100% | 100% | 100% | 69% |
+| `qwen2.5:3b-instruct` | 91% | 33% | 100% | 96% | 100% | 77% |
+| `phi3.5:latest` | 82% | 92% | 90% | 57% | 82% | 23% |
+| `qwen2.5:1.5b-instruct` | 91% | 50% | 70% | 83% | 27% | 31% |
+| `gemma:2b-instruct` | 82% | 67% | 60% | 57% | 18% | 8% |
+
+---
+
+## Min VRAM by Model Size
+
+| Min VRAM | Models that fit |
+|:--------:|----------------|
+| CPU / Any | Models under 1 GB (run without a GPU) |
+| 4 GB | Models up to ~3 GB |
+| 8 GB | Models up to ~6.5 GB |
+| 12 GB | Models up to ~11 GB (gemma3:12b, phi4, qwen2.5:14b) |
+| 16 GB | Models up to ~18 GB |
+
+> Run `python scripts/benchmark.py` to regenerate this table with your own models.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "intentKeeper",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "description": "A digital bodyguard for your mind - filters content by intent",
   "permissions": [
     "storage",

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""
+IntentKeeper model benchmark.
+
+Runs the labeled eval set (eval/test_set.yaml) through each candidate
+Ollama model and records accuracy and latency. Results go to
+docs/model-benchmark.md so users can pick the right model for their hardware.
+
+Partial results saved to docs/benchmark-results.json after each model.
+
+Usage:
+    python scripts/benchmark.py                    # all defaults
+    python scripts/benchmark.py --resume           # skip already-done models
+    python scripts/benchmark.py --models qwen2.5:7b-instruct mistral:7b-instruct
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import time
+import traceback
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT))
+
+RESULTS_FILE = ROOT / "docs" / "benchmark-results.json"
+PROBE_TIMEOUT = 30  # seconds
+
+DEFAULT_MODELS = [
+    "qwen2.5:1.5b-instruct",
+    "gemma:2b-instruct",
+    "qwen2.5:3b-instruct",
+    "llama3.2:latest",
+    "phi3.5:latest",
+    "mistral:7b-instruct",
+    "llama3.1:8b",
+    "qwen2.5:7b-instruct",
+    "dolphin-mistral:latest",
+    "gemma3:12b",
+    "phi4:latest",
+    "qwen2.5:14b-instruct-q4_K_M",
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def hardware_tier(size_gb: float) -> str:
+    if size_gb < 1.0:
+        return "CPU / Any"
+    if size_gb < 3.0:
+        return "4 GB"
+    if size_gb < 6.5:
+        return "8 GB"
+    if size_gb < 11.0:
+        return "12 GB"
+    if size_gb < 18.0:
+        return "16 GB"
+    return "24 GB"
+
+
+def format_size(size_gb: float) -> str:
+    if size_gb < 1.0:
+        return f"{size_gb * 1024:.0f} MB"
+    return f"{size_gb:.1f} GB"
+
+
+def pct(v: float) -> str:
+    return f"{v * 100:.0f}%"
+
+
+def fmt_ms(v: float) -> str:
+    if v >= 1000:
+        return f"{v / 1000:.1f}s"
+    return f"{v:.0f}ms"
+
+
+def get_installed_models() -> dict:
+    result = subprocess.run(["ollama", "list"], capture_output=True, text=True)
+    models = {}
+    lines = result.stdout.strip().splitlines()
+    if len(lines) < 2:
+        return models
+    for line in lines[1:]:
+        parts = line.split()
+        if len(parts) < 4:
+            continue
+        name = parts[0]
+        try:
+            size = float(parts[2])
+            unit = parts[3]
+            if unit == "MB":
+                size /= 1024
+            models[name] = round(size, 2)
+        except (ValueError, IndexError):
+            pass
+    return models
+
+
+def load_test_set() -> list:
+    path = ROOT / "eval" / "test_set.yaml"
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def load_partial_results() -> dict:
+    if not RESULTS_FILE.exists():
+        return {}
+    try:
+        with open(RESULTS_FILE) as f:
+            return json.load(f)
+    except Exception as e:
+        print(f"  warn: could not load {RESULTS_FILE}: {e}", flush=True)
+        return {}
+
+
+def save_partial_results(results: dict) -> None:
+    data = dict(results)
+    data["updated_at"] = datetime.now(timezone.utc).isoformat()
+    tmp = str(RESULTS_FILE) + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp, RESULTS_FILE)
+
+
+async def probe_model(model_name: str, ollama_host: str) -> bool:
+    """Quick health check - can the model respond at all within PROBE_TIMEOUT seconds."""
+    import httpx
+
+    url = f"{ollama_host}/api/generate"
+    payload = {
+        "model": model_name,
+        "prompt": "Hi",
+        "stream": False,
+        "options": {"num_predict": 5, "temperature": 0.0},
+    }
+    try:
+        async with httpx.AsyncClient() as client:
+            r = await client.post(url, json=payload, timeout=PROBE_TIMEOUT)
+            r.raise_for_status()
+            return bool(r.json().get("response"))
+    except Exception as e:
+        print(f"  probe failed for {model_name}: {e}", flush=True)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Benchmark
+# ---------------------------------------------------------------------------
+
+
+async def bench_model(model_name: str, test_set: list) -> dict:
+    """Run the full eval set through model_name. Returns metrics dict."""
+    from server.classifier import IntentClassifier
+
+    classifier = IntentClassifier(model=model_name)
+
+    total = len(test_set)
+    correct = 0
+    per_intent: dict = defaultdict(lambda: {"total": 0, "correct": 0})
+    latencies = []
+
+    for item in test_set:
+        content = item["content"]
+        expected = item["expected_intent"]
+        t0 = time.perf_counter()
+        try:
+            result = await classifier.classify(content)
+            latencies.append((time.perf_counter() - t0) * 1000)
+            got = result.intent
+            per_intent[expected]["total"] += 1
+            if got == expected:
+                correct += 1
+                per_intent[expected]["correct"] += 1
+        except Exception as e:
+            print(f"    warn [{expected}]: {e}", flush=True)
+            latencies.append((time.perf_counter() - t0) * 1000)
+            per_intent[expected]["total"] += 1
+
+    await classifier.close()
+
+    per_intent_acc = {
+        intent: counts["correct"] / counts["total"]
+        for intent, counts in per_intent.items()
+        if counts["total"] > 0
+    }
+
+    return {
+        "accuracy": correct / total if total else 0.0,
+        "correct": correct,
+        "total": total,
+        "avg_latency_ms": sum(latencies) / len(latencies) if latencies else 0.0,
+        "per_intent": per_intent_acc,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Markdown output
+# ---------------------------------------------------------------------------
+
+
+def build_markdown(results: dict, installed: dict, ts: str) -> str:
+    # Sort by accuracy descending
+    sorted_models = sorted(
+        [(m, r) for m, r in results.items() if isinstance(r, dict) and "accuracy" in r],
+        key=lambda x: x[1]["accuracy"],
+        reverse=True,
+    )
+
+    # Collect all intent names
+    all_intents = set()
+    for _, m in sorted_models:
+        all_intents.update(m.get("per_intent", {}).keys())
+    intents = sorted(all_intents)
+
+    lines = [
+        "# Model Benchmark",
+        "",
+        "Classification accuracy on the 80-example labeled eval set (`eval/test_set.yaml`).",
+        "Higher accuracy = fewer wrong classifications on real social media content.",
+        "",
+        f"_Last run: {ts}_",
+        "",
+        "---",
+        "",
+        "## Overall Accuracy",
+        "",
+        "| Model | Size | Min VRAM | Accuracy | Avg Latency/item |",
+        "|-------|------|:--------:|:--------:|:----------------:|",
+    ]
+
+    for model, m in sorted_models:
+        size_gb = installed.get(model, 0.0)
+        lines.append(
+            f"| `{model}` | {format_size(size_gb)} | {hardware_tier(size_gb)} "
+            f"| **{pct(m['accuracy'])}** ({m['correct']}/{m['total']}) "
+            f"| {fmt_ms(m['avg_latency_ms'])} |"
+        )
+
+    lines += [
+        "",
+        "## Per-Intent Accuracy",
+        "",
+        "Accuracy broken down by intent. Low scores highlight where a model struggles.",
+        "",
+    ]
+
+    # Per-intent table header
+    header = "| Model |" + "".join(f" {i} |" for i in intents)
+    sep = "|-------|" + "".join(":---------:|" for _ in intents)
+    lines += [header, sep]
+
+    for model, m in sorted_models:
+        per = m.get("per_intent", {})
+        row = f"| `{model}` |"
+        for intent in intents:
+            v = per.get(intent)
+            row += f" {pct(v) if v is not None else '-'} |"
+        lines.append(row)
+
+    lines += [
+        "",
+        "---",
+        "",
+        "## Min VRAM by Model Size",
+        "",
+        "| Min VRAM | Models that fit |",
+        "|:--------:|----------------|",
+        "| CPU / Any | Models under 1 GB (run without a GPU) |",
+        "| 4 GB | Models up to ~3 GB |",
+        "| 8 GB | Models up to ~6.5 GB |",
+        "| 12 GB | Models up to ~11 GB (gemma3:12b, phi4, qwen2.5:14b) |",
+        "| 16 GB | Models up to ~18 GB |",
+        "",
+        "> Run `python scripts/benchmark.py` to regenerate this table with your own models.",
+    ]
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+async def main_async(args):
+    installed = get_installed_models()
+    test_set = load_test_set()
+    ollama_host = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+
+    results = load_partial_results() if args.resume else {}
+    results.pop("updated_at", None)
+
+    print(
+        f"Loaded {len(test_set)} eval examples. "
+        f"Installed models: {len(installed)}. "
+        f"Benchmarking {len(args.models)} models.",
+        flush=True,
+    )
+    if args.resume and results:
+        print(f"Resuming: {len(results)} models already done.", flush=True)
+    print(flush=True)
+
+    t_start_all = time.perf_counter()
+
+    try:
+        for model in args.models:
+            if model not in installed:
+                print(f"  skip {model} (not installed)", flush=True)
+                continue
+            if args.resume and model in results:
+                print(f"  skip {model} (already done)", flush=True)
+                continue
+
+            print(f"  probing {model}...", flush=True)
+            if not await probe_model(model, ollama_host):
+                print(f"  skip {model} (probe failed - may not load)", flush=True)
+                continue
+
+            print(f"  benchmarking {model} ({len(test_set)} examples)...", flush=True)
+            try:
+                metrics = await bench_model(model, test_set)
+                results[model] = metrics
+                print(
+                    f"  -> accuracy={pct(metrics['accuracy'])} "
+                    f"({metrics['correct']}/{metrics['total']}) "
+                    f"latency={fmt_ms(metrics['avg_latency_ms'])}",
+                    flush=True,
+                )
+                save_partial_results(results)
+            except Exception as e:
+                print(f"  ERROR [{model}]: {e}", flush=True)
+                traceback.print_exc()
+                save_partial_results(results)
+
+    except KeyboardInterrupt:
+        print("\nInterrupted - saving partial results...", flush=True)
+        save_partial_results(results)
+        print(f"Partial results saved to {RESULTS_FILE}", flush=True)
+        print("Resume with: python scripts/benchmark.py --resume", flush=True)
+        sys.exit(0)
+
+    elapsed = time.perf_counter() - t_start_all
+    print(f"\nTotal runtime: {elapsed / 60:.1f} min", flush=True)
+
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    md = build_markdown(results, installed, ts)
+
+    out_path = ROOT / "docs" / "model-benchmark.md"
+    with open(out_path, "w") as f:
+        f.write(md)
+
+    save_partial_results(results)
+    print(f"Written: {out_path}", flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="IntentKeeper model benchmark")
+    parser.add_argument(
+        "--models",
+        nargs="+",
+        default=DEFAULT_MODELS,
+        help="Models to benchmark (default: curated list)",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Load existing results and skip already-benchmarked models",
+    )
+    args = parser.parse_args()
+    asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## v0.5.0 - User Control & Platform Reliability

### What's in this release

**Phase 6 complete - User-Configurable Sensitivity**
- Per-intent kill switches: toggle any intent category independently
- Allowlist: trusted accounts bypass classification entirely
- Confidence disclosure: "?" indicator on low-confidence classifications
- User corrections: pencil icon to correct wrong classifications; stored locally and injected as few-shot examples into future prompts

**Platform reliability**
- YouTube SPA navigation fixed (pushState/popstate)
- YouTube + Twitter + Reddit lazy-load guard (infinite scroll)
- Reddit comment context included in classification text

**UI rebrand**
- Extension renamed to intentKeeper throughout, new logo, redesigned popup

**Multi-browser**
- Chrome, Brave, Edge, Opera all confirmed working

**Model benchmark (`scripts/benchmark.py`)**
- Benchmarked 11 models on the 80-example eval set
- `llama3.2` (2 GB) matches 98% accuracy ceiling - recommended default
- `mistral:7b-instruct` fastest at 926ms with 96% accuracy
- Results in `docs/model-benchmark.md`, README updated with data-backed recommendations

**Version bump**
- manifest.json: 0.3.0 -> 0.5.0 (was not updated after v0.4.0 release)

## Test plan
- [ ] Load extension in Chrome - popup shows intentKeeper branding
- [ ] Per-intent toggles persist across popup close/reopen
- [ ] Add a trusted account - their content passes through unfiltered
- [ ] Correct a classification - correction appears in future prompts
- [ ] `python scripts/benchmark.py --help` runs cleanly
- [ ] CHANGELOG shows v0.5.0 as latest entry