### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to IntentKeeper are documented here.
 
+## v0.5.1 (2026-06-01) - Security Hardening
+
+### Security
+- XSS, SSRF, prompt injection mitigations and content logging fixes from full security audit (#74)
+- CORS wildcard narrowed: was `localhost:*`, now restricted to the specific API port only (#76)
+- `ollama_host` URL validation added on server startup - rejects malformed or non-HTTP(S) URLs (#76)
+
+---
+
 ## v0.5.0 (2026-04-26) - User Control & Platform Reliability
 
 **"You decide what stays. The extension gets out of the way."**

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <!-- Project -->
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
-  <img src="https://img.shields.io/badge/version-0.5.0-green.svg" alt="Version: 0.5.0">
+  <img src="https://img.shields.io/badge/version-0.5.1-green.svg" alt="Version: 0.5.1">
   <img src="https://img.shields.io/badge/accuracy-98%25-brightgreen.svg" alt="Accuracy: 98%">
 </p>
 <p align="center">

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "intentKeeper",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A digital bodyguard for your mind - filters content by intent",
   "permissions": [
     "storage",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "intentkeeper"
-version = "0.4.0"
+version = "0.5.1"
 description = "A digital bodyguard for your mind - local content intent classification"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Bump version to 0.5.1 in `pyproject.toml` and `extension/manifest.json`
- Add v0.5.1 CHANGELOG entry covering security audit fixes and CORS hardening
- Update version badge in README to 0.5.1

## Changes in this release
- Security audit: XSS, SSRF, prompt injection mitigations, content logging fixes (#74)
- CORS wildcard narrowed + `ollama_host` URL validation (#76)