### PR TITLE
chore: add MERGE_CHECKLIST, check_version.py, OLLAMA_SEED, stale docs fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ DEBUG=false
 
 # Cache settings (seconds)
 CACHE_TTL=300
+
+# Optional: pin the Ollama sampling seed for reproducible classifications.
+# Same prompt + same seed + same model = identical output every run.
+# Set to any integer (e.g. 42). Unset means non-deterministic (default).
+# OLLAMA_SEED=42

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to IntentKeeper are documented here.
 
-## v0.5.1 (2026-06-01) - Security Hardening
+## v0.5.1 (2026-06-01) - Security Hardening & API Completeness
+
+### New
+- `GET /version` endpoint: returns the server version as JSON (#82)
+- `GET /config` endpoint: returns current server configuration (model, host, max content length, debug flag) (#82)
 
 ### Security
 - XSS, SSRF, prompt injection mitigations and content logging fixes from full security audit (#74)

--- a/MERGE_CHECKLIST.md
+++ b/MERGE_CHECKLIST.md
@@ -1,0 +1,122 @@
+# Merge Checklist
+
+Read this before creating any PR. Not optional.
+
+The goal is zero surprises after merge: no stale docs, no out-of-sync
+version strings, no missing entries in files that should have been updated.
+
+---
+
+## Every PR (no exceptions)
+
+- [ ] `pytest tests/ -q` passes with no new failures
+- [ ] CHANGELOG.md has an entry describing what changed and why (not just what)
+- [ ] No debug prints, commented-out code, or TODO comments left behind
+
+---
+
+## By change type
+
+Find your change type below and check every item in that row.
+
+### New API endpoint (`server/api.py`)
+
+- [ ] `docs/architecture.md` - Endpoints list in Component Relationships section
+- [ ] `CLAUDE.md` - Core Components / Server section
+- [ ] Tests in `tests/test_classifier.py` covering the new endpoint
+
+### New environment variable
+
+- [ ] `.env.example` - add with a comment explaining what it does
+- [ ] `README.md` - Configuration section (if user-facing)
+- [ ] `CLAUDE.md` - Required Environment Variables section
+- [ ] Wired up in `server/classifier.py` or `server/api.py`
+
+### New platform adapter (`extension/platforms/`)
+
+- [ ] `extension/manifest.json` - URL patterns added to `content_scripts`
+- [ ] `docs/architecture.md` - High-Level Overview browser line, Platform Adapters section
+- [ ] `ROADMAP.md` - mark phase ✅
+- [ ] `README.md` - supported platforms list updated
+- [ ] `CLAUDE.md` - Architecture section (directory listing)
+- [ ] Tests in `extension/tests/` or `tests/`
+
+### New intent category (`scenarios/intents.yaml`)
+
+- [ ] Run eval **before** the change: `python eval/run_eval.py` - record baseline
+- [ ] `eval/test_set.yaml` - add labeled examples for the new intent
+- [ ] Run eval **after**: accuracy must not regress
+- [ ] `docs/architecture.md` - Intent Categories section (count, spectrum diagram)
+- [ ] `CLAUDE.md` - intent table updated
+
+### New extension feature (popup, `background.js`, `core/classifier.js`)
+
+- [ ] `extension/manifest.json` - new permissions declared if required
+- [ ] `docs/architecture.md` - Component Relationships if new storage keys or APIs used
+- [ ] Extension tests in `extension/tests/`
+
+### Dependency change (`pyproject.toml` or `extension/package.json`)
+
+- [ ] `Dockerfile` - any layer caching implications?
+- [ ] Verify end-to-end install still works
+
+---
+
+## Release procedure
+
+A release is any PR that bumps the public version number.
+**All four version-bearing files must match before the PR is merged.**
+
+### Version-bearing files (update all four, in this order)
+
+| File | Location | Note |
+|------|----------|------|
+| `pyproject.toml` | `version = "..."` | source of truth |
+| `extension/manifest.json` | `"version": "..."` | must match pyproject.toml |
+| `README.md` | version badge | must match |
+| `CHANGELOG.md` | top entry header | rename `[Unreleased]` to `vX.Y.Z (YYYY-MM-DD)` |
+
+To verify all four are consistent before merging, run:
+```bash
+python scripts/check_version.py
+```
+
+### Release steps (in order)
+
+1. Update all four version-bearing files above
+2. Run `python scripts/check_version.py` - must pass
+3. Run `pytest tests/ -q` - must pass
+4. Run `python eval/run_eval.py` - note accuracy, must not regress from baseline
+5. Update `ROADMAP.md` - mark completed phase ✅, update Current Status section
+6. Commit: `chore: release vX.Y.Z`
+7. Push, create PR, merge
+8. Tag: `git tag vX.Y.Z && git push origin vX.Y.Z`
+9. GitHub release: create from tag, paste CHANGELOG entry as description
+
+---
+
+## When to update this checklist
+
+Update this file when the **shape of the project changes** - a new kind of
+thing appears that this checklist does not have a row for yet.
+
+Examples that require a new row:
+- A new browser is officially supported
+- A new top-level source directory is added
+- A new external integration is added (database, service, API)
+
+Adding a new instance of an existing type (new endpoint, new platform, new
+intent) does NOT require updating this checklist - the existing rows cover it.
+
+---
+
+## Quick reference - what contains what
+
+| Concept | Files that must stay in sync |
+|---------|------------------------------|
+| Version string | `pyproject.toml`, `extension/manifest.json`, `README.md` badge, `CHANGELOG.md` header |
+| API endpoints | `server/api.py`, `docs/architecture.md`, `CLAUDE.md` |
+| Environment variables | `.env.example`, `README.md`, `CLAUDE.md`, `server/classifier.py` / `server/api.py` |
+| Platform support | `extension/manifest.json`, `extension/platforms/`, `docs/architecture.md`, `README.md`, `ROADMAP.md` |
+| Intent categories | `scenarios/intents.yaml`, `eval/test_set.yaml`, `docs/architecture.md`, `CLAUDE.md` |
+| Eval baseline | `eval/test_set.yaml`, `CLAUDE.md` baseline percentage and date |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -431,9 +431,9 @@ Safari requires Apple developer account, Xcode, and wrapping the extension in a 
 
 ---
 
-## Current Status (2026-04-26)
+## Current Status (2026-06-07)
 
-**Completed**: Phase 1 (Core + Twitter/X), Phase 2 (Hardening), Phase 3.1-3.3 + 3.5 (YouTube + platform abstraction), Phase 4 (Reddit - 3 DOM variants), Phase 5.1-5.2 (98% accuracy), Phase 6.1-6.5 (User-Configurable Sensitivity - all subphases complete), Phase 8.1 (Brave PNA middleware) - **v0.5.0 released**
+**Completed**: Phase 1 (Core + Twitter/X), Phase 2 (Hardening), Phase 3.1-3.3 + 3.5 (YouTube + platform abstraction), Phase 4 (Reddit - 3 DOM variants), Phase 5.1-5.2 (98% accuracy), Phase 6.1-6.5 (User-Configurable Sensitivity - all subphases complete), Phase 8.1 (Brave PNA middleware) - **v0.5.1 released**
 
 **Prompt ceiling**: The 2 remaining misclassified cases are at the model's training boundary. Fine-tuning (Phase 5.3) would be needed to pass 98%. Prompting cannot resolve them.
 

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Version consistency checker for intentKeeper.
+
+Reads the authoritative version from pyproject.toml and verifies that
+every other version-bearing file references the same version.
+
+Usage:
+    python scripts/check_version.py        # from repo root
+    python scripts/check_version.py --fix  # show fix hints too
+
+Exit codes:
+    0 - all files consistent
+    1 - one or more mismatches found
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def read_pyproject_version():
+    """Source of truth. Must exist and have a parseable version field."""
+    path = ROOT / "pyproject.toml"
+    if not path.exists():
+        return None, "pyproject.toml not found"
+    match = re.search(r'^version\s*=\s*"([^"]+)"', path.read_text(), re.MULTILINE)
+    if not match:
+        return None, "pyproject.toml: version field not found"
+    return match.group(1), None
+
+
+def read_manifest_version():
+    path = ROOT / "extension" / "manifest.json"
+    if not path.exists():
+        return None, "extension/manifest.json not found"
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        return None, f"extension/manifest.json: JSON parse error: {e}"
+    version = data.get("version")
+    if not version:
+        return None, 'extension/manifest.json: "version" field not found'
+    return version, None
+
+
+def read_readme_version():
+    path = ROOT / "README.md"
+    if not path.exists():
+        return None, "README.md not found"
+    match = re.search(r"version-([0-9]+\.[0-9]+(?:\.[0-9]+)?)-", path.read_text())
+    if not match:
+        return None, "README.md: version badge not found (expected version-X.Y.Z-...)"
+    return match.group(1), None
+
+
+def read_changelog_version():
+    path = ROOT / "CHANGELOG.md"
+    if not path.exists():
+        return None, "CHANGELOG.md not found"
+    match = re.search(r"^## v([0-9]+\.[0-9]+(?:\.[0-9]+)?)", path.read_text(), re.MULTILINE)
+    if not match:
+        return None, "CHANGELOG.md: no versioned header found (e.g. '## v0.5.1')"
+    return match.group(1), None
+
+
+CHECKS = [
+    (
+        "extension/manifest.json",
+        read_manifest_version,
+        'Update "version": "{version}" in extension/manifest.json',
+    ),
+    (
+        "README.md",
+        read_readme_version,
+        "Update the version badge to version-{version}-green.svg",
+    ),
+    (
+        "CHANGELOG.md",
+        read_changelog_version,
+        "Rename the top entry to ## v{version} (YYYY-MM-DD)",
+    ),
+]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check intentKeeper version consistency")
+    parser.add_argument("--fix", action="store_true", help="Show fix hints for each failure")
+    args = parser.parse_args()
+
+    canonical, err = read_pyproject_version()
+    if err:
+        print(f"ERROR: {err}")
+        sys.exit(1)
+
+    print(f"Authoritative version (pyproject.toml): {canonical}\n")
+
+    failures = []
+    for label, reader, fix_hint in CHECKS:
+        found, err = reader()
+        if err:
+            print(f"  FAIL  {label}")
+            print(f"        {err}")
+            failures.append((label, fix_hint.format(version=canonical)))
+        elif found != canonical:
+            print(f"  FAIL  {label}")
+            print(f"        found {found!r}, expected {canonical!r}")
+            failures.append((label, fix_hint.format(version=canonical)))
+        else:
+            print(f"  OK    {label}  ({found})")
+
+    print()
+
+    if not failures:
+        print("All version references consistent.")
+        sys.exit(0)
+
+    print(f"{len(failures)} file(s) out of sync.\n")
+
+    if args.fix:
+        print("Fix hints:")
+        for label, hint in failures:
+            print(f"  {label}: {hint}")
+        print()
+    else:
+        print("Run with --fix to see fix hints.")
+
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/classifier.py
+++ b/server/classifier.py
@@ -106,6 +106,8 @@ class IntentClassifier:
             if temperature is not None
             else float(os.getenv("OLLAMA_TEMPERATURE", "0.1"))
         )
+        _seed_env = os.getenv("OLLAMA_SEED", "")
+        self.seed: Optional[int] = int(_seed_env) if _seed_env.strip() else None
         self.ollama_url = f"{self.ollama_host}/api/generate"
 
         # Load intent definitions
@@ -468,15 +470,19 @@ JSON response:"""
         Uses `format: json` to nudge the model toward valid JSON output.
         The response is not parsed here - see _parse_response().
         """
+        options: dict = {
+            "temperature": self.temperature,
+            "num_predict": LLM_MAX_TOKENS,
+        }
+        if self.seed is not None:
+            options["seed"] = self.seed
+
         payload = {
             "model": self.model,
             "prompt": prompt,
             "stream": False,
             "format": "json",
-            "options": {
-                "temperature": self.temperature,
-                "num_predict": LLM_MAX_TOKENS,
-            },
+            "options": options,
         }
 
         client = await self._get_client()


### PR DESCRIPTION
## Summary

Replicates empathySync's process tooling into intentKeeper. All four items mirror what empathySync has had since v1.10.1.

- **`MERGE_CHECKLIST.md`** - pre-merge gate adapted for intentKeeper's change types: API endpoints, platform adapters, intent changes, extension features. Includes release procedure with the four version-bearing files. Same philosophy as empathySync's version.
- **`scripts/check_version.py`** - checks `pyproject.toml` (source of truth) against `extension/manifest.json`, `README.md` badge, and `CHANGELOG.md` header. Exits 1 on any mismatch. Run with `--fix` for remediation hints. Currently passes clean.
- **`OLLAMA_SEED` env var** - optional integer seed passed through to Ollama's `options.seed`. Same prompt + same seed + same model = identical output every run. Useful for deterministic eval runs. Commented out in `.env.example` (opt-in). Wired into `server/classifier.py` `_call_ollama()`.
- **CHANGELOG fix** - v0.5.1 entry was missing the `GET /version` and `GET /config` endpoints that landed in PR #82.
- **ROADMAP fix** - Current Status was dated 2026-04-26 (v0.5.0). Updated to 2026-06-07 (v0.5.1).

## Test plan

- [ ] `python3 scripts/check_version.py` outputs all OK (passes now)
- [ ] `pytest tests/ -q` passes (no classifier changes that affect test mocks)
- [ ] MERGE_CHECKLIST rows cover your next PR's change type