### PR TITLE
feat: per-call timing logs for Ollama classify and vision calls

### DIFF
--- a/server/classifier.py
+++ b/server/classifier.py
@@ -342,9 +342,13 @@ JSON response:"""
                 "options": {"temperature": 0.1, "num_predict": 80},
             }
 
+            t0 = time.monotonic()
             response = await client.post(self.ollama_url, json=payload, timeout=30)
             response.raise_for_status()
-            description = response.json().get("response", "").strip()
+            duration_s = time.monotonic() - t0
+            result = response.json()
+            logger.debug("ollama vision: duration=%.2fs model=%s", duration_s, vision_model)
+            description = result.get("response", "").strip()
             return description if description else None
 
         except Exception as e:
@@ -479,11 +483,20 @@ JSON response:"""
             },
         }
 
+        t0 = time.monotonic()
         client = await self._get_client()
         response = await client.post(self.ollama_url, json=payload)
         response.raise_for_status()
+        duration_s = time.monotonic() - t0
 
         result = response.json()
+        tokens = result.get("eval_count", 0)
+        logger.debug(
+            "ollama classify: duration=%.2fs tokens=%d model=%s",
+            duration_s,
+            tokens,
+            self.model,
+        )
         return result.get("response", "").strip()
 
     def _parse_response(self, response: str) -> ClassificationResult:


### PR DESCRIPTION
## Summary

Adds `DEBUG`-level timing logs after every Ollama call in the classification pipeline, mirroring what empathySync added in v1.10.0 for its OllamaClient.

**`server/classifier.py`**:
- `_call_ollama()`: logs `duration=Xs tokens=N model=...` after each classification call. Token count comes from Ollama's `eval_count` field in the response.
- `_describe_image()`: logs `duration=Xs model=...` after each vision call.

Both log at `DEBUG` level - invisible in normal operation, visible when `DEBUG=true` in `.env`.

## Why

Without timing data you cannot tell whether a slow session is the network, the LLM, or the vision model. With these logs you can run with `DEBUG=true`, reproduce the session, and see exactly where time is going.

## Test plan

- [ ] `pytest tests/ -q` - 93 tests pass (no behaviour change, only logging added)
- [ ] Run server with `DEBUG=true`, make a classification request, confirm log line appears: `ollama classify: duration=Xs tokens=N model=...`