### PR TITLE
feat: add Twitter Article (Notes) support to twitter adapter

### DIFF
--- a/extension/platforms/twitter.js
+++ b/extension/platforms/twitter.js
@@ -2,6 +2,7 @@
  * IntentKeeper - Twitter/X Platform Adapter
  *
  * Knows how to find tweets and extract rich text for classification.
+ * Handles standard tweets and Twitter Articles (Notes) at /i/notes/ URLs.
  * All classification logic lives in core/classifier.js.
  */
 
@@ -29,6 +30,50 @@ function getEmojiText(element) {
 }
 
 /**
+ * Return true if the current page is a Twitter Article (Notes) page.
+ * These live at /i/notes/<id>.
+ */
+function isNotesPage() {
+  return /^\/i\/notes\//.test(window.location.pathname);
+}
+
+/**
+ * Extract text from a Twitter Article element.
+ *
+ * Twitter Articles render their body inside a component with
+ * data-testid="articleRichTextJobComponent". Each paragraph is a child block.
+ * Falls back to querying the wrapping <article> element's textContent if the
+ * specific testid is absent.
+ *
+ * NOTE: These selectors need verification against the live Twitter DOM.
+ * Twitter's internal testid names change without notice. If extraction stops
+ * working, inspect a /i/notes/<id> page and update the selector below.
+ */
+function extractArticleText(articleElement) {
+  const parts = [];
+
+  // Article title - rendered as an <h1> on the notes page
+  const title = articleElement.querySelector('h1');
+  if (title) parts.push(title.textContent.trim());
+
+  // Article body paragraphs via Twitter's internal testid.
+  // Candidate selector - requires live DOM verification.
+  const bodyEl = articleElement.querySelector('[data-testid="articleRichTextJobComponent"]');
+  if (bodyEl) {
+    const bodyText = bodyEl.textContent.trim();
+    if (bodyText) parts.push(bodyText);
+  } else {
+    // Fallback: grab all paragraph text within the article element directly.
+    articleElement.querySelectorAll('p').forEach(p => {
+      const t = p.textContent.trim();
+      if (t) parts.push(t);
+    });
+  }
+
+  return parts.join(' | ');
+}
+
+/**
  * On a thread/status page (/username/status/ID), return the text of the focal
  * post - the tweet the page is anchored on.
  *
@@ -49,13 +94,21 @@ function getFocalPostText() {
 
 const twitterAdapter = {
   platform: 'twitter',
-  baseSelector: '[data-testid="tweet"]',
+  // Standard tweets plus Twitter Article containers on /i/notes/ pages.
+  // The article selector targets the outermost <article> element that wraps
+  // the Notes page body. Requires live DOM verification - Twitter may use a
+  // more specific testid (e.g. data-testid="article") in future layouts.
+  baseSelector: '[data-testid="tweet"], article[data-testid="article"]',
 
   /**
-   * The blurrable content area within a tweet.
-   * Used by the core to target blur treatment at text, not the whole tweet card.
+   * The blurrable content area within a tweet or article.
+   * Used by the core to target blur treatment at text, not the whole card.
    */
   getContentElement(element) {
+    // Article page: blur the rich-text body component if present, else <article>
+    if (element.matches('article[data-testid="article"]')) {
+      return element.querySelector('[data-testid="articleRichTextJobComponent"]') || element;
+    }
     return element.querySelector('[data-testid="tweetText"]');
   },
 
@@ -83,7 +136,12 @@ const twitterAdapter = {
   },
 
   /**
-   * Extract tweet text including author name, quoted tweets, link cards,
+   * Extract text from a tweet or Twitter Article element.
+   *
+   * For Article elements (matched via article[data-testid="article"]):
+   *   delegates to extractArticleText() which pulls title + body paragraphs.
+   *
+   * For standard tweets: extracts author name, quoted tweets, link cards,
    * video context, poll options, image alt text, and social context banners.
    * Richer context improves classification accuracy.
    *
@@ -92,6 +150,11 @@ const twitterAdapter = {
    * Emoji are preserved via getEmojiText() rather than .textContent.
    */
   extractText(tweetElement) {
+    // Twitter Article on a /i/notes/ page - use dedicated extractor
+    if (tweetElement.matches('article[data-testid="article"]')) {
+      return extractArticleText(tweetElement);
+    }
+
     // If the tweet body hasn't rendered yet (Twitter lazy-loads card content),
     // return '' so the element stays unmarked and gets picked up on the next
     // observer pass. Video/poll tweets have no tweetText by design - only skip

--- a/extension/tests/twitter.test.js
+++ b/extension/tests/twitter.test.js
@@ -124,3 +124,89 @@ describe('twitterAdapter.getBlurContainer', () => {
     expect(twitterAdapter.getBlurContainer).toBeUndefined();
   });
 });
+
+// ---- Twitter Articles (Notes) ----
+
+/**
+ * Build a mock Twitter Article element as rendered on /i/notes/ pages.
+ * Uses article[data-testid="article"] to match the adapter's baseSelector.
+ */
+function makeArticle({ title = '', body = '', paragraphs = [], richTextTestid = true } = {}) {
+  const el = document.createElement('article');
+  el.setAttribute('data-testid', 'article');
+
+  let html = '';
+
+  if (title) {
+    html += `<h1>${title}</h1>`;
+  }
+
+  if (body && richTextTestid) {
+    html += `<div data-testid="articleRichTextJobComponent">${body}</div>`;
+  } else if (paragraphs.length > 0) {
+    // Fallback structure: plain <p> elements, no testid wrapper
+    html += paragraphs.map(p => `<p>${p}</p>`).join('');
+  }
+
+  el.innerHTML = html;
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('twitterAdapter baseSelector - article support', () => {
+  test('baseSelector includes article[data-testid="article"]', () => {
+    expect(twitterAdapter.baseSelector).toContain('article[data-testid="article"]');
+  });
+});
+
+describe('twitterAdapter.extractText - Twitter Articles', () => {
+  test('extracts article title', () => {
+    const el = makeArticle({ title: 'This is the article title', body: 'Some body text.' });
+    expect(twitterAdapter.extractText(el)).toContain('This is the article title');
+  });
+
+  test('extracts article body via articleRichTextJobComponent testid', () => {
+    const el = makeArticle({ title: 'Title', body: 'The body of the article.' });
+    expect(twitterAdapter.extractText(el)).toContain('The body of the article.');
+  });
+
+  test('falls back to <p> elements when articleRichTextJobComponent is absent', () => {
+    const el = makeArticle({ paragraphs: ['First paragraph.', 'Second paragraph.'], richTextTestid: false });
+    const result = twitterAdapter.extractText(el);
+    expect(result).toContain('First paragraph.');
+    expect(result).toContain('Second paragraph.');
+  });
+
+  test('returns only title when body is empty', () => {
+    const el = makeArticle({ title: 'Just a title' });
+    expect(twitterAdapter.extractText(el)).toBe('Just a title');
+  });
+
+  test('returns empty string for article with no content', () => {
+    const el = makeArticle();
+    expect(twitterAdapter.extractText(el)).toBe('');
+  });
+
+  test('does not include tweet-specific fields for article elements', () => {
+    const el = makeArticle({ title: 'A title', body: 'Some content.' });
+    const result = twitterAdapter.extractText(el);
+    expect(result).not.toContain('[Author:');
+    expect(result).not.toContain('[Poll:');
+    expect(result).not.toContain('[Video:');
+  });
+});
+
+describe('twitterAdapter.getContentElement - Twitter Articles', () => {
+  test('returns articleRichTextJobComponent when present', () => {
+    const el = makeArticle({ title: 'T', body: 'B' });
+    const content = twitterAdapter.getContentElement(el);
+    expect(content).not.toBeNull();
+    expect(content.getAttribute('data-testid')).toBe('articleRichTextJobComponent');
+  });
+
+  test('falls back to the article element itself when testid element is absent', () => {
+    const el = makeArticle({ paragraphs: ['Some text'], richTextTestid: false });
+    const content = twitterAdapter.getContentElement(el);
+    expect(content).toBe(el);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `extractArticleText()` helper that pulls title (`<h1>`) and body text (`[data-testid="articleRichTextJobComponent"]`, with `<p>` fallback) from Twitter Article pages at `/i/notes/` URLs
- Extends `baseSelector` to include `article[data-testid="article"]` so the core observer picks up article elements alongside regular tweets
- Updates `extractText()` and `getContentElement()` to dispatch on element type - articles use the new helper, tweets use the existing path unchanged
- Selectors are annotated with a comment noting they need live DOM verification (Twitter's internal testids change without notice)

## Test plan

- [x] 9 new unit tests added in `extension/tests/twitter.test.js` covering:
  - article title extraction
  - body extraction via `articleRichTextJobComponent` testid
  - fallback to `<p>` elements when testid is absent
  - empty article returns empty string
  - article does not include tweet-specific fields (Author, Poll, Video)
  - `getContentElement` returns body component or falls back to `<article>` itself
  - `baseSelector` contains the article selector
- [x] All 9 new tests pass; 2 pre-existing failures in `core.test.js` (unrelated `formatIntent` entries) remain unchanged

## Scope note

Twitter Spaces is excluded - it is audio content with no text to classify. This PR addresses only the long-form posts (Articles/Notes) half of issue #16.

Closes #16