### PR TITLE
feat: Docker entrypoint hardening + docs-only CI skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,36 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for docs-only changes
+        id: docs-check
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          fi
+          changed=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null || git diff --name-only HEAD~1 HEAD)
+          non_docs=$(echo "$changed" | grep -Ev '^(docs/|.*\.md$|\.github/[^/]+\.md$)' || true)
+          if [ -z "$non_docs" ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "Docs-only change — skipping test suite."
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Python ${{ matrix.python-version }}
+        if: steps.docs-check.outputs.docs_only != 'true'
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip dependencies
+        if: steps.docs-check.outputs.docs_only != 'true'
         uses: actions/cache@v5
         with:
           path: ~/.cache/pip
@@ -30,15 +53,19 @@ jobs:
             ${{ runner.os }}-pip-${{ matrix.python-version }}-
 
       - name: Install dependencies
+        if: steps.docs-check.outputs.docs_only != 'true'
         run: pip install -e ".[dev]"
 
       - name: Lint with ruff
+        if: steps.docs-check.outputs.docs_only != 'true'
         run: ruff check server/
 
       - name: Check formatting with black
+        if: steps.docs-check.outputs.docs_only != 'true'
         run: black --check server/
 
       - name: Run tests
+        if: steps.docs-check.outputs.docs_only != 'true'
         run: pytest tests/ -v --cov=server --cov-report=term-missing
 
   protect-manifesto:
@@ -64,11 +91,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for docs-only changes
+        id: docs-check
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          fi
+          changed=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null || git diff --name-only HEAD~1 HEAD)
+          non_docs=$(echo "$changed" | grep -Ev '^(docs/|.*\.md$|\.github/[^/]+\.md$)' || true)
+          if [ -z "$non_docs" ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "Docs-only change — skipping extension lint."
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Validate manifest.json
+        if: steps.docs-check.outputs.docs_only != 'true'
         run: python -c "import json; json.load(open('extension/manifest.json'))"
 
       - name: Check extension files exist
+        if: steps.docs-check.outputs.docs_only != 'true'
         run: |
           test -f extension/core/classifier.js
           test -f extension/platforms/twitter.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to IntentKeeper are documented here.
 ### Eval
 - Added 12 YouTube and Reddit examples across all intent categories to improve platform coverage in the eval set (#92, closes #87)
 
+### Infrastructure
+- Docker entrypoint hardening: PUID/PGID privilege drop via `gosu`, bind-mount ownership repair on restart, SIGTERM forwarding to uvicorn; adds `docker-compose.yml` with `host.docker.internal` for reaching Ollama on the host (#95)
+- CI: docs-only PRs now skip expensive test and lint steps while still reporting a passing check - prevents blocking required status checks on pure documentation changes (#95)
+- PR template: fixed stale test count, removed Twitter-only phrasing from manual test checkbox (#94)
+
 ---
 
 ## v0.5.1 (2026-06-01) - Security Hardening & API Completeness

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,12 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# Install curl for healthcheck
-RUN apt-get update && apt-get install -y --no-install-recommends curl \
+# gosu lets the entrypoint drop privileges cleanly so SIGTERM from
+# `docker stop` reaches uvicorn directly (no extra shell layer).
+# curl is needed for the healthcheck.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    gosu \
     && rm -rf /var/lib/apt/lists/*
 
 # Install dependencies
@@ -13,9 +17,15 @@ COPY scenarios/ scenarios/
 
 RUN pip install --no-cache-dir -e .
 
+RUN mkdir -p data logs
+
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 EXPOSE 8420
 
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
     CMD curl -f http://localhost:8420/health || exit 1
 
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["intentkeeper-server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  intentkeeper:
+    build: .
+    container_name: intentkeeper
+    ports:
+      - "${APP_BIND:-127.0.0.1}:${APP_PORT:-8420}:8420"
+    volumes:
+      - ./.env:/app/.env:ro
+      - ./data:/app/data
+    environment:
+      - OLLAMA_HOST=${OLLAMA_HOST:-http://host.docker.internal:11434}
+      - OLLAMA_MODEL=${OLLAMA_MODEL:-mistral:7b-instruct}
+      # Match your host user: run `id -u` and `id -g` to find these.
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+    extra_hosts:
+      # Lets the container reach Ollama running on the Docker host.
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Drop from root to PUID:PGID before starting the server.
+#
+# Without this the container writes root-owned files into bind-mounted
+# host volumes and the host user can't edit them without sudo.
+#
+# Set PUID/PGID in docker-compose.yml or your .env to match your host user:
+#   id -u   # find your PUID
+#   id -g   # find your PGID
+set -e
+
+PUID="${PUID:-1000}"
+PGID="${PGID:-1000}"
+
+if ! getent group "$PGID" >/dev/null 2>&1; then
+    groupadd -g "$PGID" intentkeeper
+fi
+if ! getent passwd "$PUID" >/dev/null 2>&1; then
+    useradd -u "$PUID" -g "$PGID" -M -s /bin/sh -d /app intentkeeper
+fi
+
+# Repair ownership on writable paths so files written by a previous
+# root run don't block the non-root user on restart.
+for dir in /app/data /app/logs; do
+    if [ -d "$dir" ]; then
+        find "$dir" -not -uid "$PUID" -print0 2>/dev/null \
+            | xargs -0 -r chown "$PUID:$PGID" 2>/dev/null || true
+    fi
+done
+
+# exec + gosu: no extra shell layer, so SIGTERM from `docker stop`
+# reaches uvicorn directly instead of being swallowed by a wrapper.
+exec gosu "$PUID:$PGID" "$@"


### PR DESCRIPTION
## Summary

Two infrastructure improvements mirroring what was done for empathySync:

**Docker hardening:**
- Adds `docker/entrypoint.sh`: drops from root to `PUID:PGID`, repairs bind-mount ownership on restart, uses `gosu` + `exec` for clean SIGTERM forwarding
- Updates `Dockerfile`: installs `gosu`, uses the new entrypoint script
- Adds `docker-compose.yml`: intentKeeper had a Dockerfile but no compose file; this adds one with `host.docker.internal` for reaching Ollama on the Docker host, localhost-only port binding, and `PUID`/`PGID` support

**Docs-only CI skip:**
- Adds `docs-check` step to `test` and `extension-lint` jobs: skips expensive steps when all changed files are docs/markdown
- `protect-manifesto` always runs regardless

## Testing

- [ ] `pytest tests/ -q` passes
- [ ] `ruff check server/` passes
- [ ] `docker build .` succeeds