### PR TITLE
eval: broaden fearmongering coverage + divisive/ragebait boundary few-shot (#97, #98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to IntentKeeper are documented here.
 
 ### Eval
 - Added 12 YouTube and Reddit examples across all intent categories to improve platform coverage in the eval set (#92, closes #87)
+- Added 6 fearmongering examples to `eval/test_set.yaml` - YouTube suppressed-truth/personal-danger framing and Reddit r/collapse & r/preppers doom posts, plus two facts-with-source genuine boundary cases - to broaden coverage of the fear/genuine edge; all six classify correctly (fearmongering subset 16/16) (closes #97)
+- Added 4 divisive/ragebait boundary few-shot examples to `scenarios/intents.yaml` to sharpen the sort-into-a-tribe (divisive) vs make-you-furious (ragebait) distinction; divisive eval accuracy 100% with no ragebait regression (closes #98)
 
 ### Infrastructure
 - Docker entrypoint hardening: PUID/PGID privilege drop via `gosu`, bind-mount ownership repair on restart, SIGTERM forwarding to uvicorn; adds `docker-compose.yml` with `host.docker.internal` for reaching Ollama on the host (#95)

--- a/eval/test_set.yaml
+++ b/eval/test_set.yaml
@@ -1,8 +1,9 @@
 # IntentKeeper Eval Test Set
 #
-# 80 labeled examples, ~13 per intent.
-# Each intent has 4-5 clear cases and 3-4 boundary/tricky cases.
-# Boundary cases are marked with a note explaining why they might be confused.
+# 98 labeled examples across 6 intents (genuine is the largest - it is the
+# pass-through class and absorbs the most boundary cases).
+# Most intents mix clear cases with boundary/tricky cases; boundary cases carry
+# a note explaining why they might be confused with an adjacent intent.
 #
 # To add new examples: add to the appropriate intent section.
 # To run: python eval/run_eval.py
@@ -140,6 +141,31 @@
 - content: "You won't believe what hackers can see through your webcam while you sleep"
   expected_intent: fearmongering
   note: "youtube - threat amplification and personal danger framing"
+
+# platform coverage: YouTube + Reddit fearmongering patterns (#97)
+- content: "Doctors HATE this - the truth about your tap water they don't want out"
+  expected_intent: fearmongering
+  note: "youtube - authority-suppression framing ('they don't want out') with vague health threat"
+
+- content: "What they're NOT telling you about this winter could put your whole family at risk"
+  expected_intent: fearmongering
+  note: "youtube - suppressed-truth framing ('not telling you') plus vague personal-danger threat, no specifics"
+
+- content: "r/collapse: It's happening faster than the models predicted. We have maybe a few years left."
+  expected_intent: fearmongering
+  note: "reddit - doom framing with vague 'models' appeal and no source, manufactured certainty"
+
+- content: "r/preppers: They're not telling you how bad the grid actually is. Stock up before winter."
+  expected_intent: fearmongering
+  note: "reddit - suppressed-truth framing with unspecified 'they' and urgency to act"
+
+- content: "r/science: New peer-reviewed study links the additive to a 12% rise in the disorder (n=40,000)."
+  expected_intent: genuine
+  note: "boundary fearmongering/genuine - alarming topic but specific study, sample size, and peer review = genuine, not fear"
+
+- content: "r/news: Officials confirm the recall affects 3 states; full list and batch numbers in the article."
+  expected_intent: genuine
+  note: "boundary - serious subject delivered with specific, verifiable facts and a source; informational, not fearmongering"
 
 
 # ─── hype ────────────────────────────────────────────────────────────────────

--- a/scenarios/intents.yaml
+++ b/scenarios/intents.yaml
@@ -242,6 +242,26 @@ few_shot_examples:
     intent: ragebait
     reasoning: "Rhetorical question designed to provoke contempt for a named person. Despite the question form, this is not genuine curiosity - 'Is it just me or' is a sarcastic setup, and 'literally everything' is absolutist contempt framing. Sarcastic credibility attacks = ragebait."
 
+  # --- divisive/ragebait boundary (#98) ---
+  # The hardest edge: same heat, different goal. Ask what the author wants you
+  # to do (sort into a tribe = divisive) vs feel (fury at a target = ragebait).
+
+  - content: "r/unpopularopinion: People who bring toddlers to fancy restaurants have decided their comfort matters more than everyone else's."
+    intent: divisive
+    reasoning: "Sorts people by a behaviour choice into a moral category ('decided their comfort matters more'). The move is to make the reader judge and self-sort, not to ignite fury at a villain. Behaviour-based moral sorting = divisive. It would tip to ragebait only if contempt or mockery aimed at those parents were the dominant signal, not the sorting."
+
+  - content: "I cannot BELIEVE this 'expert' still gets airtime after the garbage he pushed last year. Absolute clown show."
+    intent: ragebait
+    reasoning: "Mockery and contempt aimed at one specific person (scare-quoted 'expert', 'clown show'). There is no tribe to join - the goal is to make you furious at a single target, not to assign you to a side. Personal contemptuous ridicule = ragebait, not divisive."
+
+  - content: "Remote workers and office workers will never understand each other. Two different species at this point honestly."
+    intent: divisive
+    reasoning: "Manufactures a binary between two groups ('two different species'). The exaggeration adds heat, but the primary structure is sorting the reader into one camp against the other, not provoking outrage at a wrongdoer. Binary group framing = divisive even when the tone runs hot."
+
+  - content: "Imagine seeing all of this and still doing nothing. Some of you really need to take a long hard look at yourselves."
+    intent: ragebait
+    reasoning: "Accusatory callout ('take a long hard look at yourselves') engineered to provoke shame and anger. Although 'some of you' gestures at a group, the dominant signal is moral fury directed at the reader, not tribal sorting. Contemptuous guilt-demand = ragebait."
+
   # --- genuine ---
 
   - content: "I've been dealing with anxiety for 10 years. Here's what actually helped me, though everyone's different."


### PR DESCRIPTION
## Summary

Resolves two classification-quality issues in one pass (both YAML, no code):

**#97 - fearmongering eval coverage.** Added 6 examples to `eval/test_set.yaml`:
- YouTube: suppressed-truth (`Doctors HATE this...`) and personal-danger (`What they're NOT telling you about this winter...`) framing
- Reddit: r/collapse and r/preppers doom posts
- Two facts-with-source **genuine** boundary cases (r/science peer-reviewed study, r/news official recall) so the set tests the fear/genuine edge in both directions

All six classify correctly - fearmongering subset is **16/16 (100%)** on `gemma3:12b`. Also refreshed the stale file header (claimed 80 examples; now 98).

**#98 - divisive/ragebait boundary few-shot.** Added 4 examples to `scenarios/intents.yaml`, each with a `reasoning:` field that names which signal dominates: sort-into-a-tribe = divisive, fury-at-a-target = ragebait. Platform-varied (Reddit r/unpopularopinion, generic). Divisive eval accuracy is **100%** after the change, with no ragebait regression.

## Testing

- `python -m pytest tests/ -q` -> **93 passed**
- `OLLAMA_MODEL=gemma3:12b python eval/run_eval.py` -> **93/98 (95%)** overall; fearmongering subset **16/16**, divisive **12/12**
- Both YAML files validated with `yaml.safe_load`

**Note on the headline number:** overall eval is 95%, below the README's `98%` badge. That 98% was measured 2026-04-09 on the original 80-example set. The set has since grown to 98 with deliberately harder boundary cases (#92 and this PR). All 5 remaining misses are **pre-existing** documented boundary cases (e.g. the `WHO data` and `job security` genuine-not-fearmongering cases, and the #92 r/AskReddit & r/AmItheAsshole cases) - none introduced here. The stale `98%` badge is worth a separate look.