### PR TITLE
test: Jest coverage for the Reddit adapter + fix stale core tests (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to IntentKeeper are documented here.
 ### New
 - Twitter Article (Notes) support: classifies long-form posts at `/i/notes/` URLs - extracts title and body via `articleRichTextJobComponent` testid with `<p>` fallback; article elements added to `baseSelector` alongside tweets (#90, closes #16)
 
+### Tests
+- Added `extension/tests/reddit.test.js` - 20 Jest tests covering the Reddit adapter across all three DOM variants (Shreddit, old new Reddit, old Reddit): title/subreddit/flair extraction, unloaded-shell empty-string behaviour, comment extraction, content-element selection, and author extraction (closes #91)
+- Fixed two stale `core.test.js` assertions that referenced intents removed in the 9->6 streamlining (`neutral`, `clickbait`, `reaction_farming`) - they now assert the current fall-back-to-raw-string behaviour, so `npm test` is green again (76/76)
+
 ### Eval
 - Added 12 YouTube and Reddit examples across all intent categories to improve platform coverage in the eval set (#92, closes #87)
 - Added 6 fearmongering examples to `eval/test_set.yaml` - YouTube suppressed-truth/personal-danger framing and Reddit r/collapse & r/preppers doom posts, plus two facts-with-source genuine boundary cases - to broaden coverage of the fear/genuine edge; all six classify correctly (fearmongering subset 16/16) (closes #97)

--- a/extension/tests/core.test.js
+++ b/extension/tests/core.test.js
@@ -29,19 +29,22 @@ describe('hashContent', () => {
 });
 
 describe('formatIntent', () => {
-  test('formats all core Twitter intents', () => {
+  test('formats all six v2 intents', () => {
     expect(formatIntent('ragebait')).toBe('Ragebait');
     expect(formatIntent('fearmongering')).toBe('Fear-mongering');
     expect(formatIntent('hype')).toBe('Hype');
     expect(formatIntent('engagement_bait')).toBe('Engagement Bait');
     expect(formatIntent('divisive')).toBe('Divisive');
     expect(formatIntent('genuine')).toBe('Genuine');
-    expect(formatIntent('neutral')).toBe('Neutral');
   });
 
-  test('formats YouTube-specific intents added in Phase 3', () => {
-    expect(formatIntent('clickbait')).toBe('Clickbait');
-    expect(formatIntent('reaction_farming')).toBe('Reaction Farming');
+  test('legacy intents merged in the 9->6 streamlining fall back to their raw string', () => {
+    // clickbait -> hype, reaction_farming -> engagement_bait, neutral -> genuine.
+    // These labels are no longer in the map; formatIntent returns them unchanged
+    // rather than crashing, so any stale payload still renders something.
+    expect(formatIntent('clickbait')).toBe('clickbait');
+    expect(formatIntent('reaction_farming')).toBe('reaction_farming');
+    expect(formatIntent('neutral')).toBe('neutral');
   });
 
   test('returns the raw string for unknown intents rather than crashing', () => {

--- a/extension/tests/reddit.test.js
+++ b/extension/tests/reddit.test.js
@@ -1,0 +1,239 @@
+/**
+ * Tests for extension/platforms/reddit.js
+ * Covers text extraction, content-element selection, and author extraction
+ * across all three Reddit DOM variants: Shreddit, old new Reddit, and old Reddit.
+ */
+
+const { redditAdapter } = require('../platforms/reddit');
+
+// Elements must be attached to the document for jsdom to compute textContent.
+// extractText's old-Reddit branch keys off window.location.hostname, so tests
+// that need it set the hostname and afterEach restores the jsdom default.
+function setHostname(hostname) {
+  Object.defineProperty(window, 'location', {
+    value: { hostname },
+    writable: true,
+    configurable: true,
+  });
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  setHostname('localhost');
+});
+
+// ---- DOM helpers: Shreddit (current Reddit) ----
+
+/**
+ * Build a mock <shreddit-post>. Pass loaded:false to simulate the element
+ * shell appearing before its title content has rendered.
+ */
+function makeShredditPost({ title = '', subreddit = '', flair = '', loaded = true } = {}) {
+  const el = document.createElement('shreddit-post');
+  if (subreddit) el.setAttribute('subreddit-prefixed-name', subreddit);
+  if (loaded && title) {
+    const slot = document.createElement('h3');
+    slot.setAttribute('slot', 'title');
+    slot.textContent = title;
+    el.appendChild(slot);
+  }
+  if (flair) {
+    const flairEl = document.createElement('span');
+    flairEl.setAttribute('slot', 'flair');
+    flairEl.textContent = flair;
+    el.appendChild(flairEl);
+  }
+  document.body.appendChild(el);
+  return el;
+}
+
+function makeShredditComment({ body = '', author = '' } = {}) {
+  const el = document.createElement('shreddit-comment');
+  if (author) el.setAttribute('author', author);
+  if (body) {
+    const slot = document.createElement('div');
+    slot.setAttribute('slot', 'comment');
+    slot.textContent = body;
+    el.appendChild(slot);
+  }
+  document.body.appendChild(el);
+  return el;
+}
+
+// ---- DOM helpers: old new Reddit (pre-Shreddit) ----
+
+function makeNewRedditPost({ title = '' } = {}) {
+  const el = document.createElement('div');
+  el.setAttribute('data-testid', 'post-container');
+  if (title) {
+    const h3 = document.createElement('h3');
+    h3.textContent = title;
+    el.appendChild(h3);
+  }
+  document.body.appendChild(el);
+  return el;
+}
+
+// ---- DOM helpers: old Reddit (old.reddit.com) ----
+
+function makeOldRedditPost({ title = '', subreddit = '' } = {}) {
+  const el = document.createElement('div');
+  el.className = 'thing link';
+  const titleWrap = document.createElement('p');
+  titleWrap.className = 'title';
+  if (title) {
+    const a = document.createElement('a');
+    a.className = 'title';
+    a.textContent = title;
+    titleWrap.appendChild(a);
+  }
+  el.appendChild(titleWrap);
+  if (subreddit) {
+    const sub = document.createElement('a');
+    sub.className = 'subreddit';
+    sub.textContent = subreddit;
+    el.appendChild(sub);
+  }
+  document.body.appendChild(el);
+  return el;
+}
+
+// ---- Adapter metadata ----
+
+describe('redditAdapter metadata', () => {
+  test('platform is reddit', () => {
+    expect(redditAdapter.platform).toBe('reddit');
+  });
+
+  test('baseSelector targets shreddit-post in the default (Shreddit) branch', () => {
+    // jsdom has no <shreddit-app>, so baseSelector falls through to the
+    // old-new-Reddit branch by default; assert that branch's selectors.
+    expect(redditAdapter.baseSelector).toContain('post-container');
+  });
+});
+
+// ---- extractText: Shreddit ----
+
+describe('redditAdapter.extractText - Shreddit', () => {
+  test('extracts post title from the title slot', () => {
+    const el = makeShredditPost({ title: 'Scientists discover new species' });
+    expect(redditAdapter.extractText(el)).toContain('Scientists discover new species');
+  });
+
+  test('includes subreddit context when present', () => {
+    const el = makeShredditPost({ title: 'A post', subreddit: 'r/science' });
+    expect(redditAdapter.extractText(el)).toContain('[r/science]');
+  });
+
+  test('includes flair when present', () => {
+    const el = makeShredditPost({ title: 'A post', flair: 'Discussion' });
+    expect(redditAdapter.extractText(el)).toContain('[Flair: Discussion]');
+  });
+
+  test('returns empty string for an unloaded post shell', () => {
+    const el = makeShredditPost({ title: 'Not rendered yet', loaded: false });
+    expect(redditAdapter.extractText(el)).toBe('');
+  });
+
+  test('extracts comment body and includes author', () => {
+    const el = makeShredditComment({ body: 'This is a terrible take.', author: 'spez' });
+    const result = redditAdapter.extractText(el);
+    expect(result).toContain('This is a terrible take.');
+    expect(result).toContain('[u/spez]');
+  });
+
+  test('returns empty string for an unrendered comment', () => {
+    const el = makeShredditComment({ body: '' });
+    expect(redditAdapter.extractText(el)).toBe('');
+  });
+});
+
+// ---- extractText: old new Reddit ----
+
+describe('redditAdapter.extractText - old new Reddit', () => {
+  test('extracts post title from h3', () => {
+    const el = makeNewRedditPost({ title: 'Breaking: something happened' });
+    expect(redditAdapter.extractText(el)).toContain('Breaking: something happened');
+  });
+
+  test('returns empty string when the title has not loaded', () => {
+    const el = makeNewRedditPost({ title: '' });
+    expect(redditAdapter.extractText(el)).toBe('');
+  });
+});
+
+// ---- extractText: old Reddit ----
+
+describe('redditAdapter.extractText - old Reddit', () => {
+  test('extracts post title from .title a (hostname old.reddit.com)', () => {
+    setHostname('old.reddit.com');
+    const el = makeOldRedditPost({ title: 'An old.reddit post title' });
+    expect(redditAdapter.extractText(el)).toContain('An old.reddit post title');
+  });
+
+  test('includes subreddit context on old Reddit', () => {
+    setHostname('old.reddit.com');
+    const el = makeOldRedditPost({ title: 'A post', subreddit: 'r/AskHistorians' });
+    expect(redditAdapter.extractText(el)).toContain('[r/AskHistorians]');
+  });
+});
+
+// ---- getContentElement ----
+
+describe('redditAdapter.getContentElement', () => {
+  test('Shreddit post returns the title slot', () => {
+    const el = makeShredditPost({ title: 'Title here' });
+    const content = redditAdapter.getContentElement(el);
+    expect(content.getAttribute('slot')).toBe('title');
+  });
+
+  test('Shreddit comment returns the comment slot', () => {
+    const el = makeShredditComment({ body: 'A comment' });
+    const content = redditAdapter.getContentElement(el);
+    expect(content.getAttribute('slot')).toBe('comment');
+  });
+
+  test('old Reddit link returns the title container', () => {
+    const el = makeOldRedditPost({ title: 'Old title' });
+    const content = redditAdapter.getContentElement(el);
+    expect(content.classList.contains('title')).toBe(true);
+  });
+
+  test('new Reddit post container returns its h3', () => {
+    const el = makeNewRedditPost({ title: 'New title' });
+    const content = redditAdapter.getContentElement(el);
+    expect(content.tagName.toLowerCase()).toBe('h3');
+  });
+});
+
+// ---- extractAuthor ----
+
+describe('redditAdapter.extractAuthor', () => {
+  test('reads the author attribute on Shreddit elements, lowercased', () => {
+    const el = makeShredditComment({ body: 'x', author: 'SpezHimself' });
+    expect(redditAdapter.extractAuthor(el)).toBe('spezhimself');
+  });
+
+  test('reads the .author element on old Reddit', () => {
+    const el = makeOldRedditPost({ title: 'x' });
+    const author = document.createElement('a');
+    author.className = 'author';
+    author.textContent = 'OldRedditor';
+    el.appendChild(author);
+    expect(redditAdapter.extractAuthor(el)).toBe('oldredditor');
+  });
+
+  test('returns null when no author is present', () => {
+    const el = makeNewRedditPost({ title: 'No author here' });
+    expect(redditAdapter.extractAuthor(el)).toBeNull();
+  });
+});
+
+// ---- getBlurContainer ----
+
+describe('redditAdapter.getBlurContainer', () => {
+  test('returns null - Reddit is text-based, blur falls back to content element', () => {
+    const el = makeShredditPost({ title: 'x' });
+    expect(redditAdapter.getBlurContainer(el)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #91 and repairs the extension test suite, which had two pre-existing failures.

**#91 - Reddit adapter Jest tests.** New `extension/tests/reddit.test.js` (20 tests) covering all three DOM variants the adapter handles:
- **Shreddit**: title-slot extraction, subreddit context, flair, the unloaded-shell `''` contract, comment body + author
- **old new Reddit**: `h3` title extraction, empty when unloaded
- **old Reddit**: `.title a` extraction and subreddit context (these mock `window.location.hostname = 'old.reddit.com'`, since `extractText` dispatches on hostname)
- `getContentElement` for each variant, `extractAuthor` across variants, and `getBlurContainer` returning null

Follows the existing `twitter.test.js` pattern (DOM-builder helpers, `afterEach` cleanup).

**Stale test fix.** `core.test.js` had two failing assertions referencing intents removed in the 9->6 streamlining (`neutral`, `clickbait`, `reaction_farming` were merged into `genuine`/`hype`/`engagement_bait`). `formatIntent` correctly returns the raw string for them now; the tests were never updated. They now assert that fall-back behaviour.

## Testing

- `cd extension && npm test` -> **76/76 passing** (was 54 passing + 2 failing on main)
- `npx jest tests/reddit.test.js` -> 20/20

Note: CI does not run jest (the `extension-lint` job only validates `manifest.json` and file presence), so these failures weren't visible in CI - but `npm test` is the documented local command in #91's acceptance criteria, and it's green now.