### PR TITLE
docs: refresh stale 98% accuracy claim against the current 98-example set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to IntentKeeper are documented here.
 - Added 6 fearmongering examples to `eval/test_set.yaml` - YouTube suppressed-truth/personal-danger framing and Reddit r/collapse & r/preppers doom posts, plus two facts-with-source genuine boundary cases - to broaden coverage of the fear/genuine edge; all six classify correctly (fearmongering subset 16/16) (closes #97)
 - Added 4 divisive/ragebait boundary few-shot examples to `scenarios/intents.yaml` to sharpen the sort-into-a-tribe (divisive) vs make-you-furious (ragebait) distinction; divisive eval accuracy 100% with no ragebait regression (closes #98)
 
+### Docs
+- Refreshed the stale `98%` accuracy claim. That figure was `78/80` on the original 80-example set (2026-04-09); the set has since grown to 98 with harder boundary cases. Re-measured on 2026-06-14: `llama3.1:8b`/`qwen2.5:14b` 96%, `gemma3:12b` 95%, `mistral:7b-instruct` 94%, `llama3.2` 93%. Updated the README badge (98% -> 96%), accuracy paragraph, and recommended-models table; `CLAUDE.md` baseline; and added a dated spot-check to `docs/model-benchmark.md` (the full 80-example table is kept as a labeled snapshot). Note the reversal: on the harder set the 8B+ models now lead the 2 GB `llama3.2`, so `llama3.1:8b` replaces `llama3.2` as the recommended default
+
 ### Infrastructure
 - Docker entrypoint hardening: PUID/PGID privilege drop via `gosu`, bind-mount ownership repair on restart, SIGTERM forwarding to uvicorn; adds `docker-compose.yml` with `host.docker.internal` for reaching Ollama on the host (#95)
 - CI: docs-only PRs now skip expensive test and lint steps while still reporting a passing check - prevents blocking required status checks on pure documentation changes (#95)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,11 +74,13 @@ These are non-negotiable. Every feature decision should be checked against them.
 
 ## Eval Harness
 
-`eval/test_set.yaml` is a labeled test set of 80 examples (~13 per intent) used to measure
+`eval/test_set.yaml` is a labeled test set of 98 examples used to measure
 classification accuracy. `eval/run_eval.py` runs them through the classifier and reports
 per-intent accuracy and wrong classifications.
 
-**Current baseline: 98% accuracy** (78/80 correct, measured 2026-04-09).
+**Current baseline: 96% accuracy** (94/98 with `llama3.1:8b`, measured 2026-06-14). Most
+remaining misses are deliberately included boundary cases. The harness reads `OLLAMA_MODEL`
+from the environment - it does not auto-load `.env`.
 
 **Rule: run the eval before AND after any change to `scenarios/intents.yaml`.**
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <!-- Project -->
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <img src="https://img.shields.io/badge/version-0.5.1-green.svg" alt="Version: 0.5.1">
-  <img src="https://img.shields.io/badge/accuracy-98%25-brightgreen.svg" alt="Accuracy: 98%">
+  <img src="https://img.shields.io/badge/accuracy-96%25-brightgreen.svg" alt="Accuracy: 96%">
   <a href="https://github.com/Olawoyin007/intentKeeper/actions/workflows/ci.yml"><img src="https://github.com/Olawoyin007/intentKeeper/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
 </p>
 <p align="center">
@@ -54,7 +54,7 @@ A post about politics can be thoughtful analysis or manufactured outrage. A heal
 
 IntentKeeper classifies the **manipulation patterns** in content - not the topics themselves. It doesn't censor subjects. It flags the framing patterns associated with ragebait, fearmongering, divisive content, and hype before they land.
 
-**Accuracy**: 98% on an 80-example labeled eval set (measured 2026-04-09). The remaining 2% are at the model's training boundary - prompt engineering cannot resolve them without breaking other cases. Classification confidence is shown alongside each label so you know when the model is uncertain.
+**Accuracy**: up to 96% on a 98-example labeled eval set (measured 2026-06-14 with `llama3.1:8b` / `qwen2.5:14b`). The set has grown harder over time - most remaining misses are deliberately included boundary cases, like alarming-but-sourced facts labeled genuine. Classification confidence is shown alongside each label so you know when the model is uncertain.
 
 ## Quick Start
 
@@ -86,15 +86,16 @@ intentkeeper-server
 OLLAMA_MODEL=your-model-name
 ```
 
-**Recommended models** (benchmarked on the 80-example eval set - see [`docs/model-benchmark.md`](docs/model-benchmark.md)):
+**Recommended models** (measured on the 98-example eval set, 2026-06-14 - see [`docs/model-benchmark.md`](docs/model-benchmark.md)):
 
 | Min VRAM | Model | Accuracy | Latency |
 |:--------:|-------|:--------:|:-------:|
-| 4 GB | `llama3.2:latest` | 98% | 1.5s |
-| 8 GB | `mistral:7b-instruct` | 96% | 0.9s |
-| 8 GB | `llama3.1:8b` | 98% | 1.8s |
+| 4 GB | `llama3.2:latest` | 93% | 1.5s |
+| 8 GB | `mistral:7b-instruct` | 94% | 0.9s |
+| 8 GB | `llama3.1:8b` | 96% | 1.8s |
+| 12 GB | `qwen2.5:14b-instruct-q4_K_M` | 96% | 2.6s |
 
-`llama3.2` (2 GB) hits the same 98% accuracy ceiling as models 4x its size - the best default for most hardware. `mistral:7b-instruct` is the fastest option if speed matters more than the 2% gap.
+On the current set the 8B+ models lead at ~96%; `llama3.1:8b` is the best all-round default. `llama3.2` (2 GB) is the lightest option at 93% - a few points behind on the harder boundary cases but fine for low-VRAM machines. `mistral:7b-instruct` is the fastest if latency matters most.
 
 Don't have Ollama yet? [Install it here](https://ollama.com) - it runs entirely on your hardware, no cloud required.
 

--- a/docs/model-benchmark.md
+++ b/docs/model-benchmark.md
@@ -1,13 +1,27 @@
 # Model Benchmark
 
-Classification accuracy on the 80-example labeled eval set (`eval/test_set.yaml`).
+Classification accuracy on the labeled eval set (`eval/test_set.yaml`).
 Higher accuracy = fewer wrong classifications on real social media content.
 
-_Last run: 2026-04-26 14:24 UTC_
+_Last full benchmark: 2026-04-26 14:24 UTC, on the then-80-example set._
+
+> **2026-06-14 spot-check (current 98-example set).** The eval set has since grown to 98
+> examples with harder boundary cases, so the headline numbers have moved:
+>
+> | Model | Min VRAM | Accuracy |
+> |-------|:--------:|:--------:|
+> | `llama3.1:8b` | 8 GB | 96% (94/98) |
+> | `qwen2.5:14b-instruct-q4_K_M` | 12 GB | 96% (94/98) |
+> | `gemma3:12b` | 12 GB | 95% (93/98) |
+> | `mistral:7b-instruct` | 8 GB | 94% (92/98) |
+> | `llama3.2:latest` | 4 GB | 93% (91/98) |
+>
+> Note the reversal from the table below: on the harder set the 8B+ models pull ahead of
+> the 2 GB `llama3.2`. Regenerate the full table with `python scripts/benchmark.py`.
 
 ---
 
-## Overall Accuracy
+## Overall Accuracy (80-example set, 2026-04-26)
 
 | Model | Size | Min VRAM | Accuracy | Avg Latency/item |
 |-------|------|:--------:|:--------:|:----------------:|


### PR DESCRIPTION
## Summary

Follow-up to the finding flagged in #99: the README's `98%` accuracy badge was stale. That figure was `78/80` on the **original 80-example** set (measured 2026-04-09). The set has since grown to **98 examples** with deliberately harder boundary cases (#92, #99), so I re-measured every documented model on the current set.

**Re-measured 2026-06-14** (`OLLAMA_MODEL=<m> python eval/run_eval.py`):

| Model | Accuracy on 98-example set |
|-------|:--:|
| `llama3.1:8b` | 96% (94/98) |
| `qwen2.5:14b-instruct-q4_K_M` | 96% (94/98) |
| `gemma3:12b` | 95% (93/98) |
| `mistral:7b-instruct` | 94% (92/98) |
| `llama3.2:latest` | 93% (91/98) |

**The narrative reversed.** The README claimed `llama3.2` (2 GB) "hits the same 98% ceiling as models 4x its size - the best default." On the harder set it's now the *weakest* (93%), and the 8B+ models lead at 96%. So `llama3.1:8b` replaces `llama3.2` as the recommended default.

### Changes
- README: badge `98% -> 96%`, accuracy paragraph, recommended-models table (fresh numbers + new framing)
- `CLAUDE.md`: eval baseline `98% (78/80)` -> `96% (94/98)`, set size `80 -> 98`
- `docs/model-benchmark.md`: added a dated **2026-06-14 spot-check** callout; the full 11-model table is kept as a clearly-labeled **80-example / 2026-04-26** snapshot (it's script-generated and timestamped, not re-run here)

### Deliberately not changed
- `ROADMAP.md` historical measurements (`78/80 on 80 examples`, dated) - point-in-time records
- The full per-model benchmark table - regenerating all 11 models on the new set is a separate `scripts/benchmark.py` run

## Testing

- Each number above produced by `eval/run_eval.py` on the current `main` eval set (98 examples)
- No code changed; docs only