### PR TITLE
chore: remove unused CONFIDENCE_HIGH constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to IntentKeeper are documented here.
 ### Fixed
 - `normalizeWhitespace` helper collapses internal runs of whitespace/newlines (and trims) on extracted post text in `processItems()`, before it is hashed and length-checked. Adapters previously only `.trim()`ed the ends, so multi-line YouTube/Twitter/Reddit blobs produced unstable cache keys (same post, different internal spacing -> cache miss -> redundant classification) and could slip past the `MIN_CONTENT_LENGTH` gate on padding alone (closes #106)
 
+### Removed
+- Dropped the unused `CONFIDENCE_HIGH = 0.85` constant from `classifier.js`. The Phase 6.4 spec lists "high confidence: standard treatment", which is the default else-case and needs no branch, so the constant was never read. `CONFIDENCE_LOW` (which gates the "?" uncertainty marker) is retained; ROADMAP 6.4 updated to match
+
 ### Tests
 - Added `extension/tests/reddit.test.js` - 20 Jest tests covering the Reddit adapter across all three DOM variants (Shreddit, old new Reddit, old Reddit): title/subreddit/flair extraction, unloaded-shell empty-string behaviour, comment extraction, content-element selection, and author extraction (closes #91)
 - Fixed two stale `core.test.js` assertions that referenced intents removed in the 9->6 streamlining (`neutral`, `clickbait`, `reaction_farming`) - they now assert the current fall-back-to-raw-string behaviour, so `npm test` is green again (76/76)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -244,7 +244,7 @@
 - [x] High confidence (>0.85): standard treatment
 - [x] Tooltip: "Classified as ragebait (confidence: 72%)"
 - [x] Blur overlay: low-confidence note rendered inline
-- [x] `CONFIDENCE_LOW` / `CONFIDENCE_HIGH` constants in classifier.js
+- [x] `CONFIDENCE_LOW` constant in classifier.js (high confidence is the default treatment, so no `CONFIDENCE_HIGH` constant is needed)
 
 ### 6.5 User Override & Local Corrections ✅ DONE
 **Philosophy**: Corrections stored locally only in `chrome.storage.local`. Nothing leaves the device.

--- a/extension/core/classifier.js
+++ b/extension/core/classifier.js
@@ -314,9 +314,9 @@ async function classifyBatch(batchItems, platform) {
 
 // --- Visual Treatments ---
 
-// Confidence thresholds matching Phase 6.4 spec
+// Low-confidence threshold (Phase 6.4 spec): below this, the label is muted and
+// gets a "?" suffix. High confidence needs no constant - it's the default treatment.
 const CONFIDENCE_LOW = 0.65;
-const CONFIDENCE_HIGH = 0.85;
 
 function applyTag(element, intent, confidence, content) {
   const tag = document.createElement('div');


### PR DESCRIPTION
## Summary

`CONFIDENCE_HIGH = 0.85` in `extension/core/classifier.js` is defined but never read anywhere in the extension. The Phase 6.4 confidence-disclosure spec lists "high confidence: standard treatment" - but standard treatment is the default else-case when a classification is *not* low confidence, so it needs no branch and no constant. Only `CONFIDENCE_LOW` (which gates the muted label + `?` uncertainty marker) is actually used.

This removes the dead constant, tidies the threshold comment, and updates the ROADMAP 6.4 checklist line so the docs no longer claim a `CONFIDENCE_HIGH` constant that isn't there. `CONFIDENCE_LOW` is retained unchanged.

## Testing

- `npx jest` in `extension/`: 81/81 pass
- Confirmed `CONFIDENCE_HIGH` has no remaining references in the repo (only the now-updated ROADMAP line referenced it)