### PR TITLE
release: v0.6.0 - Long-Form Posts & Eval Depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to IntentKeeper are documented here.
 
-## [Unreleased]
+## v0.6.0 (2026-07-02) - Long-Form Posts & Eval Depth
 
 ### Security
 - Cleared all 21 npm audit advisories in the extension dev toolchain (all transitive under `jest`, dev-only - the extension ships content scripts, not `node_modules`, so there was no runtime/user exposure). `npm audit fix` bumped `ws` 8.20.x -> 8.21.0 (high: uninitialized memory disclosure + fragment DoS) and `@babel/core` -> 7.29.7 (low: arbitrary file read via `sourceMappingURL`, #9). Added an `overrides` pin of `js-yaml` `^4.2.0` to clear the quadratic-complexity merge-key DoS (#10) and its 17 dependents - the advisory covers `<=4.1.1`, and `@istanbuljs/load-nyc-config` (the only consumer, used in coverage) tolerates the 4.x API. Verified: `npm audit` 0 vulnerabilities, plain and `--coverage` Jest runs both 81/81

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <!-- Project -->
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
-  <img src="https://img.shields.io/badge/version-0.5.1-green.svg" alt="Version: 0.5.1">
+  <img src="https://img.shields.io/badge/version-0.6.0-green.svg" alt="Version: 0.6.0">
   <img src="https://img.shields.io/badge/accuracy-96%25-brightgreen.svg" alt="Accuracy: 96%">
   <a href="https://github.com/Olawoyin007/intentKeeper/actions/workflows/ci.yml"><img src="https://github.com/Olawoyin007/intentKeeper/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
 </p>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -433,7 +433,7 @@ Safari requires Apple developer account, Xcode, and wrapping the extension in a 
 
 ## Current Status (2026-06-07)
 
-**Completed**: Phase 1 (Core + Twitter/X), Phase 2 (Hardening), Phase 3.1-3.3 + 3.5 (YouTube + platform abstraction), Phase 4 (Reddit - 3 DOM variants), Phase 5.1-5.2 (98% accuracy), Phase 6.1-6.5 (User-Configurable Sensitivity - all subphases complete), Phase 8.1 (Brave PNA middleware) - **v0.5.1 released**
+**Completed**: Phase 1 (Core + Twitter/X), Phase 2 (Hardening), Phase 3.1-3.3 + 3.5 (YouTube + platform abstraction), Phase 4 (Reddit - 3 DOM variants), Phase 5.1-5.2 (98% accuracy), Phase 6.1-6.5 (User-Configurable Sensitivity - all subphases complete), Phase 8.1 (Brave PNA middleware) - **v0.6.0 released** (2026-07-02)
 
 **Prompt ceiling**: The 2 remaining misclassified cases are at the model's training boundary. Fine-tuning (Phase 5.3) would be needed to pass 98%. Prompting cannot resolve them.
 
@@ -473,7 +473,7 @@ IntentKeeper shares architectural DNA with [empathySync](https://github.com/Olaw
 **v0.3.0** (Phase 3): YouTube support ✅ COMPLETE (platform abstraction done, intent anchoring deferred)
 **v0.4.0** (Phase 4): Reddit support ✅ COMPLETE
 **v0.5.0** (Phase 5): Classification accuracy - 98% reached ✅ COMPLETE (prompt ceiling; fine-tuning needed for final 2%)
-**v0.6.0** (Phase 6): User-configurable sensitivity
+**v0.6.0**: Twitter Articles (Notes) support + eval expansion (fearmongering/divisive/hype) + security & CI hardening (npm audit cleared, Jest in CI, Docker entrypoint) ✅ COMPLETE (2026-07-02). Note: Phase 6 (user-configurable sensitivity) shipped earlier in v0.5.0/v0.5.1, so this line no longer maps to Phase 6.
 **v0.7.0** (Phase 7): Statistics dashboard
 **v0.8.0** (Phase 8): Multi-browser support (Brave, Edge, Opera, Firefox)
 **v0.8.5** (Phase 8.5): Non-technical user access - DEFERRED

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "intentKeeper",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "A digital bodyguard for your mind - filters content by intent",
   "permissions": [
     "storage",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "intentkeeper"
-version = "0.5.1"
+version = "0.6.0"
 description = "A digital bodyguard for your mind - local content intent classification"
 readme = "README.md"
 license = {text = "MIT"}

--- a/server/api.py
+++ b/server/api.py
@@ -83,7 +83,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="IntentKeeper",
     description="Local content intent classification API",
-    version="0.5.1",
+    version="0.6.0",
     lifespan=lifespan,
 )
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -397,7 +397,7 @@ class TestAPIEndpoints:
         assert response.status_code == 200
         data = response.json()
         assert "version" in data
-        assert data["version"] == "0.5.1"
+        assert data["version"] == "0.6.0"
 
     @pytest.mark.asyncio
     async def test_config_endpoint(self, mock_classifier):


### PR DESCRIPTION
## Summary

Release v0.6.0. Renames the `[Unreleased]` CHANGELOG section to `## v0.6.0 (2026-07-02) - Long-Form Posts & Eval Depth` and bumps the version across every version-bearing spot: `pyproject.toml`, `extension/manifest.json`, `README.md` badge, the FastAPI app `version=` in `server/api.py`, and the `/version` assertion in `tests/test_classifier.py`.

Contents (already merged to main under `[Unreleased]`): Twitter Article (Notes) classification (#90, closes #16), a `normalizeWhitespace` fix for stable cache keys (#106), eval expansion (fearmongering/divisive/hype boundary cases), the THREAT_MODEL.md engineering-controls table + CORS-gap correction (#114), the npm-audit dev-toolchain cleanup (21 advisories), and Jest-in-CI + Docker entrypoint hardening.

ROADMAP: the stale `v0.6.0 = Phase 6` mapping is corrected - Phase 6 (user-configurable sensitivity) actually shipped in v0.5.0/v0.5.1, so v0.6.0 is described by its real content instead.

## Testing

- `python scripts/check_version.py` - all files consistent at 0.6.0
- `pytest tests/ -q` - 93 passed
- `npm test` (extension) - 81 passed, 5 suites