### PR TITLE
fix: remove dead chrome-extension://* CORS entry (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to IntentKeeper are documented here.
 
+## [Unreleased]
+
+### Security
+- Removed the dead `chrome-extension://*` entry from the CORS `allow_origins` list in `server/api.py`. Starlette matches `allow_origins` by exact string, so the literal never matched a real extension origin - it was misleading config, not an active allowance. No behaviour change: the extension reaches the server via MV3 `host_permissions`, which bypass page CORS, and CORS continues to fail closed for extension origins. Added a comment explaining this and flipped the test that had asserted the dead entry was present (closes #113)
+
 ## v0.6.0 (2026-07-02) - Long-Form Posts & Eval Depth
 
 ### Security

--- a/server/api.py
+++ b/server/api.py
@@ -102,12 +102,15 @@ class PrivateNetworkAccessMiddleware(BaseHTTPMiddleware):
 
 app.add_middleware(PrivateNetworkAccessMiddleware)
 
-# CORS — restrict to the browser extension and the specific port this server runs on.
-# Wildcarding the port (localhost:*) would allow any page on any localhost port to make
-# credentialed requests here. Locking to INTENTKEEPER_PORT keeps the surface minimal.
+# CORS: lock credentialed access to the specific port this server runs on.
+# The browser extension does NOT depend on CORS - MV3 host_permissions for this port let the
+# service worker's own fetches bypass page CORS. So this allowlist only governs credentialed
+# requests from web pages, and we keep it to INTENTKEEPER_PORT. Wildcarding the port
+# (localhost:*) would let any page on any localhost port make credentialed requests here.
+# A literal "chrome-extension://*" used to sit here but was dead config: Starlette matches
+# allow_origins by exact string, so it never matched a real extension origin (see issue #113).
 _server_port = os.getenv("INTENTKEEPER_PORT", "8420")
 _allowed_origins = [
-    "chrome-extension://*",
     f"http://localhost:{_server_port}",
     f"http://127.0.0.1:{_server_port}",
 ]

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -872,7 +872,10 @@ class TestCORSOrigins:
         assert "http://localhost:*" not in _allowed_origins
         assert "http://127.0.0.1:*" not in _allowed_origins
 
-    def test_chrome_extension_wildcard_preserved(self):
+    def test_chrome_extension_literal_not_present(self):
+        # The literal "chrome-extension://*" was dead config: Starlette matches allow_origins
+        # by exact string, so it never matched a real extension origin. The extension reaches
+        # the server via MV3 host_permissions, not CORS. Removed in issue #113.
         from server.api import _allowed_origins
 
-        assert "chrome-extension://*" in _allowed_origins
+        assert "chrome-extension://*" not in _allowed_origins


### PR DESCRIPTION
## Summary

Closes #113. Removes the `chrome-extension://*` literal from the CORS `allow_origins` list in `server/api.py`.

Starlette's `CORSMiddleware` matches `allow_origins` by exact string, so `chrome-extension://*` never matched a real `chrome-extension://<id>` origin - it was dead, misleading config, not an active allowance. This is a hygiene change with **no behaviour change**:

- The extension reaches the server via MV3 `host_permissions`, which bypass page CORS for the service worker's own fetches. It never relied on this entry.
- CORS continues to fail closed for extension origins (the correct, over-restrictive posture).

I deliberately did **not** take the issue's alternative (`allow_origin_regex=r"chrome-extension://.*"`): that would open credentialed CORS to *any* installed Chrome extension - a real widening of the surface - to "fix" something that isn't broken.

Also added a comment at the CORS block explaining why the extension does not depend on CORS, and flipped the test that had asserted the dead entry was present.

## Testing

- `python scripts/check_version.py` - consistent at 0.6.0
- `pytest tests/ -q` - 93 passed (includes the updated `TestCORSOrigins` case)