### PR TITLE
docs: mark Phase 3 header COMPLETE in ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -110,7 +110,7 @@
 
 ---
 
-## Phase 3: YouTube Support 🔜 PLANNED
+## Phase 3: YouTube Support ✅ COMPLETE (3.4 intent anchoring deferred)
 
 **Goal**: Extend classification to YouTube titles, descriptions, and comments.
 


### PR DESCRIPTION
## Summary

The `## Phase 3: YouTube Support` header still carried `🔜 PLANNED`, but every sub-phase inside it is checked `✅ DONE` except 3.4 (intent anchoring), which is explicitly deferred - and the status section at the bottom of the file already records Phase 3 as shipped in v0.3.0. One-line header fix: `✅ COMPLETE (3.4 intent anchoring deferred)`.

## Testing

Docs-only change; no code paths affected. CI's docs-only skip applies.