### PR TITLE
docs: refresh eval baseline to the 105-example set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ All notable changes to IntentKeeper are documented here.
 ### Changed
 - ROADMAP.md now carries an execution contract (test/eval verify commands,
   PR-per-sub-phase, principles gate) and "Done when / Verify / Pitfalls"
-  acceptance blocks on the planned phases (7.1-7.3, 8.2), so an implementing
-  agent of any capability can execute a phase without rediscovering repo
-  constraints. Store submissions marked as human tasks. Stale status fixed:
-  priority matrix rows (Phase 3, 6, 7), status date, and the eval stat now
+  acceptance blocks on the planned phases (7.1-7.3, 8.2), so any work
+  session can execute a phase without rediscovering repo constraints.
+  Store submissions marked as human tasks. Stale status fixed: priority
+  matrix rows (Phase 3, 6, 7), status date, and the eval stat now
   reflecting the 105-example set (~96% on llama3.1:8b).
+- Refreshed the stale 98-example eval figures. The set grew to 105 in v0.6.0
+  but README, CLAUDE.md, and docs/model-benchmark.md still carried the
+  98-example baseline. Re-measured 2026-07-10: `llama3.1:8b` 96% (101/105),
+  all four misses `engagement_bait` boundary cases. Added a dated spot-check
+  to docs/model-benchmark.md; other models keep their dated 2026-06-14
+  numbers until re-measured.
 
 ### Security
 - Removed the dead `chrome-extension://*` entry from the CORS `allow_origins` list in `server/api.py`. Starlette matches `allow_origins` by exact string, so the literal never matched a real extension origin - it was misleading config, not an active allowance. No behaviour change: the extension reaches the server via MV3 `host_permissions`, which bypass page CORS, and CORS continues to fail closed for extension origins. Added a comment explaining this and flipped the test that had asserted the dead entry was present (closes #113)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,11 +74,11 @@ These are non-negotiable. Every feature decision should be checked against them.
 
 ## Eval Harness
 
-`eval/test_set.yaml` is a labeled test set of 98 examples used to measure
+`eval/test_set.yaml` is a labeled test set of 105 examples used to measure
 classification accuracy. `eval/run_eval.py` runs them through the classifier and reports
 per-intent accuracy and wrong classifications.
 
-**Current baseline: 96% accuracy** (94/98 with `llama3.1:8b`, measured 2026-06-14). Most
+**Current baseline: 96% accuracy** (101/105 with `llama3.1:8b`, measured 2026-07-10). Most
 remaining misses are deliberately included boundary cases. The harness reads `OLLAMA_MODEL`
 from the environment - it does not auto-load `.env`.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A post about politics can be thoughtful analysis or manufactured outrage. A heal
 
 IntentKeeper classifies the **manipulation patterns** in content - not the topics themselves. It doesn't censor subjects. It flags the framing patterns associated with ragebait, fearmongering, divisive content, and hype before they land.
 
-**Accuracy**: up to 96% on a 98-example labeled eval set (measured 2026-06-14 with `llama3.1:8b` / `qwen2.5:14b`). The set has grown harder over time - most remaining misses are deliberately included boundary cases, like alarming-but-sourced facts labeled genuine. Classification confidence is shown alongside each label so you know when the model is uncertain.
+**Accuracy**: up to 96% on a 105-example labeled eval set (measured 2026-07-10 with `llama3.1:8b`). The set has grown harder over time - most remaining misses are deliberately included boundary cases, like alarming-but-sourced facts labeled genuine. Classification confidence is shown alongside each label so you know when the model is uncertain.
 
 ## Quick Start
 

--- a/docs/model-benchmark.md
+++ b/docs/model-benchmark.md
@@ -5,7 +5,17 @@ Higher accuracy = fewer wrong classifications on real social media content.
 
 _Last full benchmark: 2026-04-26 14:24 UTC, on the then-80-example set._
 
-> **2026-06-14 spot-check (current 98-example set).** The eval set has since grown to 98
+> **2026-07-10 spot-check (current 105-example set).** The set grew from 98 to 105 in
+> v0.6.0 (YouTube/Reddit, fearmongering, and hype boundary additions):
+>
+> | Model | Min VRAM | Accuracy |
+> |-------|:--------:|:--------:|
+> | `llama3.1:8b` | 8 GB | 96% (101/105) |
+>
+> All four misses are `engagement_bait` boundary cases. Other models were not
+> re-measured on the 105 set; their most recent numbers are the 2026-06-14 table below.
+
+> **2026-06-14 spot-check (98-example set).** The eval set has since grown to 98
 > examples with harder boundary cases, so the headline numbers have moved:
 >
 > | Model | Min VRAM | Accuracy |


### PR DESCRIPTION
## Summary
- fix the eval-count drift: the set grew to 105 examples in v0.6.0 but README, CLAUDE.md, and docs/model-benchmark.md still said 98
- re-measured the full set today rather than extrapolating: `llama3.1:8b` 96% (101/105), all four misses are `engagement_bait` boundary cases (three are noted as deliberate edge cases in the test set itself)
- added a dated 2026-07-10 spot-check to docs/model-benchmark.md; the 2026-06-14 per-model table stays as a labeled snapshot since only llama3.1:8b was re-measured
- reworded the pending Unreleased CHANGELOG entry's roadmap description and added an entry for this refresh

## Testing
- `OLLAMA_MODEL=llama3.1:8b python3 eval/run_eval.py`: 101/105 (96%)
- docs-only otherwise; no code touched
