### PR TITLE
docs: defer Phase 7 (statistics dashboard) pending manifesto reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to IntentKeeper are documented here.
 ## [Unreleased]
 
 ### Changed
+- Phase 7 (Statistics Dashboard) deferred pending manifesto reconciliation.
+  The manifesto commits intentKeeper to "doesn't track or nudge" and its
+  Living Clause forbids changes that add tracking; exposure counters sit in
+  that grey zone and the 7.3 insights would model the user's browsing rhythm
+  outright. Per the project's own rule, the manifesto wins until a discussion
+  issue resolves the tension.
 - ROADMAP.md now carries an execution contract (test/eval verify commands,
   PR-per-sub-phase, principles gate) and "Done when / Verify / Pitfalls"
   acceptance blocks on the planned phases (7.1-7.3, 8.2), so any work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,4 +198,5 @@ Phases 1-6, 8.1 complete. See `ROADMAP.md` for full history.
 Current version: check `pyproject.toml` (source of truth).
 Run `python3 scripts/check_version.py` to verify all files are in sync.
 
-Phase 7 (Statistics Dashboard) is the next planned phase.
+Phase 8.2 (Firefox support) is the next planned phase. Phase 7 (Statistics
+Dashboard) is deferred pending manifesto reconciliation - see ROADMAP.md.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -286,9 +286,21 @@ them as the acceptance test, not as suggestions.
 
 ---
 
-## Phase 7: Statistics Dashboard 🔜 PLANNED
+## Phase 7: Statistics Dashboard ⏸ DEFERRED (manifesto tension, 2026-07-11)
 
 **Goal**: Show users their content exposure patterns (local only).
+
+> **Deferred** - this phase conflicts with the manifesto as written. The
+> empathySync comparison table says intentKeeper "doesn't track or nudge", the
+> Living Clause forbids changes that add tracking, and 7.3's insights ("you
+> encounter more ragebait on weekends") model the user's browsing rhythm, which
+> brushes against the "no user profiling" commitment. Local aggregate
+> feed-composition stats (7.1/7.2) are arguably transparency about the
+> environment rather than tracking of the user, but that distinction is not one
+> the manifesto currently makes. Do not implement until a manifesto discussion
+> issue resolves the tension (tighten the manifesto to carve out pull-only,
+> local, feed-not-user measurement - or retire the phase). The manifesto wins
+> until then.
 
 ### 7.1 Local Analytics
 - [ ] Track classifications by intent over time
@@ -483,7 +495,7 @@ Safari requires Apple developer account, Xcode, and wrapping the extension in a 
 
 **Prompt ceiling**: The 2 remaining misclassified cases are at the model's training boundary. Fine-tuning (Phase 5.3) would be needed to pass 98%. Prompting cannot resolve them.
 
-**Next Up**: Phase 7 (Statistics Dashboard) or Phase 8.2 (Firefox support)
+**Next Up**: Phase 8.2 (Firefox support). Phase 7 deferred 2026-07-11 pending manifesto reconciliation (see the Phase 7 deferral note).
 
 **Stats**:
 
@@ -520,7 +532,7 @@ IntentKeeper shares architectural DNA with [empathySync](https://github.com/Olaw
 **v0.4.0** (Phase 4): Reddit support ✅ COMPLETE
 **v0.5.0** (Phase 5): Classification accuracy - 98% reached ✅ COMPLETE (prompt ceiling; fine-tuning needed for final 2%)
 **v0.6.0**: Twitter Articles (Notes) support + eval expansion (fearmongering/divisive/hype) + security & CI hardening (npm audit cleared, Jest in CI, Docker entrypoint) ✅ COMPLETE (2026-07-02). Note: Phase 6 (user-configurable sensitivity) shipped earlier in v0.5.0/v0.5.1, so this line no longer maps to Phase 6.
-**v0.7.0** (Phase 7): Statistics dashboard
+**v0.7.0** (Phase 7): Statistics dashboard - DEFERRED (manifesto tension)
 **v0.8.0** (Phase 8): Multi-browser support (Brave, Edge, Opera, Firefox)
 **v0.8.5** (Phase 8.5): Non-technical user access - DEFERRED
 **v1.0.0** (Phase 9): Advanced classification features


### PR DESCRIPTION
## Summary

Defers Phase 7 rather than implementing it against the manifesto. The conflict, recorded in the ROADMAP deferral note:

- The empathySync comparison table commits intentKeeper to "doesn't track or nudge", and the Living Clause forbids changes that add tracking - local aggregate exposure counters sit in that grey zone.
- 7.3's insights ("you encounter more ragebait on weekends") go further: they model the user's browsing rhythm, which brushes the "no user profiling" commitment.
- 7.1/7.2 are arguably transparency about the feed rather than tracking of the user, but the manifesto does not currently make that distinction, and per the project's own rule the manifesto wins.

Unblocking requires a manifesto discussion issue first (tighten it to carve out pull-only, local, feed-not-user measurement - or retire the phase).

Also updates the stale "next planned phase" pointers: ROADMAP Next Up + version targets, CLAUDE.md. Next up is now Phase 8.2 (Firefox support).

## Testing

Docs-only. `grep` confirms no remaining references naming Phase 7 as next/planned.