### PR TITLE
feat: add Firefox support via cross-browser build (Phase 8.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ All notable changes to IntentKeeper are documented here.
   flags (issue #117). Host/port precedence is CLI flag > environment variable
   (`INTENTKEEPER_HOST`/`INTENTKEEPER_PORT`) > built-in default; `--version`
   prints the server version and exits. Running with no flags is unchanged.
+- Firefox support (Phase 8.2). A new `extension/build.js` (`npm run build`)
+  emits per-browser bundles from one source manifest: `dist/chrome` keeps the
+  MV3 service worker, `dist/firefox` uses an event-page `background.scripts`
+  and the mandatory `browser_specific_settings.gecko.id`. The three files that
+  call extension APIs (`background.js`, `core/classifier.js`, `popup/popup.js`)
+  now use a one-line `globalThis.browser = globalThis.browser || globalThis.chrome`
+  alias and promise-based `browser.*`, so the same code runs on Chromium (where
+  `browser` aliases MV3's promise-based `chrome`) and Firefox (native promises).
+  Chose the alias over vendoring `webextension-polyfill` - it is lighter and
+  keeps the existing `onMessage` `return true`/`sendResponse` pattern, which is
+  native on both engines. All 81 Jest tests pass unchanged. Manual Firefox
+  Developer Edition smoke test and AMO submission remain (human tasks).
 
 ### Documentation
 - `docs/model-benchmark.md`: added a 2026-07-13 full sweep (full 105-example

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -352,11 +352,11 @@ Chrome, Brave, Edge, and Opera all run Chromium and support Manifest V3 natively
 
 Firefox uses a different extension format and has subtle WebExtensions API incompatibilities with Chrome MV3. This requires real porting work.
 
-- [ ] Port Manifest V3 to Firefox MV3 format (`browser_specific_settings`, `browser_action` vs `action`)
-- [ ] Audit and fix any `chrome.*` calls not covered by the WebExtensions polyfill
-- [ ] Handle Firefox's stricter Content Security Policy
-- [ ] Test on Firefox Developer Edition
-- [ ] Prepare for Mozilla Add-ons (AMO) submission - **human task**: AMO account + review submission; agent prepares the artifact
+- [x] Port Manifest V3 to Firefox MV3 format - `build.js` emits `dist/chrome` (service worker) and `dist/firefox` (event-page `background.scripts` + mandatory `browser_specific_settings.gecko.id`) from one source manifest
+- [x] Audit and fix any `chrome.*` calls - all three call-site files (`background.js`, `core/classifier.js`, `popup/popup.js`) now use a one-line `globalThis.browser = globalThis.browser || globalThis.chrome` alias + promise-based `browser.*` (lighter than vendoring the polyfill, and native `onMessage` `return true`/`sendResponse` still works on both)
+- [x] Handle Firefox's stricter Content Security Policy - verified no inline scripts, event handlers, or `eval`; `popup.html` loads `popup.js` externally, so the default MV3 CSP is satisfied with no override
+- [ ] Test on Firefox Developer Edition - **human task**: load `dist/firefox` via `about:debugging`
+- [ ] Prepare for Mozilla Add-ons (AMO) submission - **human task**: AMO account + review submission; `dist/firefox` is the artifact
 - [ ] Privacy policy document
 - [ ] Extension description and screenshots
 

--- a/extension/.gitignore
+++ b/extension/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,3 +1,7 @@
+// Cross-browser shim: Firefox exposes promise-based extension APIs on `browser`;
+// Chrome MV3 exposes them on `chrome`. Alias so this file uses promise-based `browser.*`.
+globalThis.browser = globalThis.browser || globalThis.chrome;
+
 /**
  * IntentKeeper Background Service Worker
  *
@@ -31,11 +35,11 @@ const DEFAULT_SETTINGS = {
 /**
  * Initialize settings on install
  */
-chrome.runtime.onInstalled.addListener(async () => {
+browser.runtime.onInstalled.addListener(async () => {
   // Set default settings
-  const stored = await chrome.storage.local.get('intentkeeper_settings');
+  const stored = await browser.storage.local.get('intentkeeper_settings');
   if (!stored.intentkeeper_settings) {
-    await chrome.storage.local.set({ intentkeeper_settings: DEFAULT_SETTINGS });
+    await browser.storage.local.set({ intentkeeper_settings: DEFAULT_SETTINGS });
   }
 });
 
@@ -80,7 +84,7 @@ async function classifyContent(content, source) {
  */
 async function loadCorrectionsForPrompt() {
   try {
-    const stored = await chrome.storage.local.get('ik_corrections');
+    const stored = await browser.storage.local.get('ik_corrections');
     const corrections = stored.ik_corrections || [];
     // Most recent 5, formatted for the server
     return corrections.slice(-5).map(c => ({
@@ -125,7 +129,7 @@ async function classifyBatch(items) {
 /**
  * Handle messages from content scripts and popup
  */
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'CHECK_HEALTH') {
     checkApiHealth().then(data => {
       sendResponse(data);
@@ -154,7 +158,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 
   if (message.type === 'GET_SETTINGS') {
-    chrome.storage.local.get('intentkeeper_settings').then(stored => {
+    browser.storage.local.get('intentkeeper_settings').then(stored => {
       sendResponse(stored.intentkeeper_settings || DEFAULT_SETTINGS);
     }).catch(() => {
       sendResponse(DEFAULT_SETTINGS);
@@ -163,7 +167,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 
   if (message.type === 'SAVE_SETTINGS') {
-    chrome.storage.local.set({ intentkeeper_settings: message.settings }).then(() => {
+    browser.storage.local.set({ intentkeeper_settings: message.settings }).then(() => {
       sendResponse({ success: true });
     }).catch(() => {
       sendResponse({ success: false });
@@ -179,11 +183,11 @@ async function updateBadge() {
   const health = await checkApiHealth();
 
   if (health.status === 'ok') {
-    chrome.action.setBadgeText({ text: '' });
-    chrome.action.setBadgeBackgroundColor({ color: '#4CAF50' });
+    browser.action.setBadgeText({ text: '' });
+    browser.action.setBadgeBackgroundColor({ color: '#4CAF50' });
   } else {
-    chrome.action.setBadgeText({ text: '!' });
-    chrome.action.setBadgeBackgroundColor({ color: '#f44336' });
+    browser.action.setBadgeText({ text: '!' });
+    browser.action.setBadgeBackgroundColor({ color: '#f44336' });
   }
 }
 

--- a/extension/build.js
+++ b/extension/build.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * Build script: emits per-browser extension bundles into dist/.
+ *
+ * Chrome/Chromium (MV3) uses background.service_worker; Firefox MV3 uses an
+ * event page (background.scripts) and requires browser_specific_settings.gecko.id
+ * for stable storage. Rather than sniff the browser at runtime, we emit two
+ * manifests from one source of truth (manifest.json = the Chrome manifest).
+ */
+const fs = require('fs');
+const path = require('path');
+
+const root = __dirname;
+const dist = path.join(root, 'dist');
+
+// Everything the manifest references. Legacy/dev-only files (content.js,
+// tests/, htmlcov/) are intentionally excluded from the shipped bundle.
+const INCLUDE = ['background.js', 'styles.css', 'core', 'platforms', 'popup', 'icons'];
+
+// Stable add-on identity for Firefox. Required for storage persistence; change
+// before AMO submission if a different namespace is preferred.
+const GECKO_ID = 'intentkeeper@olawoyin007.github.io';
+const GECKO_MIN_VERSION = '128.0'; // first Firefox ESR with stable MV3 support
+
+function copyInto(targetDir) {
+  fs.rmSync(targetDir, { recursive: true, force: true });
+  fs.mkdirSync(targetDir, { recursive: true });
+  for (const item of INCLUDE) {
+    fs.cpSync(path.join(root, item), path.join(targetDir, item), { recursive: true });
+  }
+}
+
+const base = JSON.parse(fs.readFileSync(path.join(root, 'manifest.json'), 'utf8'));
+
+// Chrome / Chromium: manifest as-is (service worker background).
+const chromeDir = path.join(dist, 'chrome');
+copyInto(chromeDir);
+fs.writeFileSync(path.join(chromeDir, 'manifest.json'), JSON.stringify(base, null, 2) + '\n');
+
+// Firefox: event-page background + mandatory gecko settings.
+const firefox = JSON.parse(JSON.stringify(base));
+delete firefox.background.service_worker;
+firefox.background.scripts = ['background.js'];
+firefox.browser_specific_settings = {
+  gecko: { id: GECKO_ID, strict_min_version: GECKO_MIN_VERSION },
+};
+const firefoxDir = path.join(dist, 'firefox');
+copyInto(firefoxDir);
+fs.writeFileSync(path.join(firefoxDir, 'manifest.json'), JSON.stringify(firefox, null, 2) + '\n');
+
+console.log('Built dist/chrome and dist/firefox');

--- a/extension/core/classifier.js
+++ b/extension/core/classifier.js
@@ -1,3 +1,7 @@
+// Cross-browser shim: Firefox exposes promise-based extension APIs on `browser`;
+// Chrome MV3 exposes them on `chrome`. Alias so this file uses promise-based `browser.*`.
+globalThis.browser = globalThis.browser || globalThis.chrome;
+
 /**
  * IntentKeeper Core - Shared Classification Engine
  *
@@ -115,7 +119,7 @@ function formatIntent(intent) {
 
 async function loadSettings() {
   try {
-    const stored = await chrome.storage.local.get('intentkeeper_settings');
+    const stored = await browser.storage.local.get('intentkeeper_settings');
     if (stored.intentkeeper_settings) {
       settings = { ...settings, ...stored.intentkeeper_settings };
     }
@@ -125,7 +129,7 @@ async function loadSettings() {
 }
 
 // React to settings/allowlist changes without requiring a page reload
-chrome.storage.onChanged.addListener((changes, area) => {
+browser.storage.onChanged.addListener((changes, area) => {
   if (area !== 'local') return;
   if (changes.intentkeeper_settings) {
     const newSettings = changes.intentkeeper_settings.newValue;
@@ -149,7 +153,7 @@ let allowlist = new Set();
 
 async function loadAllowlist() {
   try {
-    const stored = await chrome.storage.local.get(ALLOWLIST_KEY);
+    const stored = await browser.storage.local.get(ALLOWLIST_KEY);
     allowlist = new Set(stored[ALLOWLIST_KEY] || []);
   } catch (e) {
     debug.log('Failed to load allowlist');
@@ -164,7 +168,7 @@ const ALL_INTENTS = ['ragebait', 'fearmongering', 'hype', 'engagement_bait', 'di
 
 async function saveCorrection(snippet, originalIntent, correctedIntent) {
   try {
-    const stored = await chrome.storage.local.get(CORRECTIONS_KEY);
+    const stored = await browser.storage.local.get(CORRECTIONS_KEY);
     const corrections = stored[CORRECTIONS_KEY] || [];
     corrections.push({
       snippet: snippet.slice(0, 200),
@@ -174,7 +178,7 @@ async function saveCorrection(snippet, originalIntent, correctedIntent) {
     });
     // LRU: keep most recent MAX_CORRECTIONS
     if (corrections.length > MAX_CORRECTIONS) corrections.splice(0, corrections.length - MAX_CORRECTIONS);
-    await chrome.storage.local.set({ [CORRECTIONS_KEY]: corrections });
+    await browser.storage.local.set({ [CORRECTIONS_KEY]: corrections });
     debug.log(`Correction saved: ${originalIntent} -> ${correctedIntent}`);
   } catch (e) {
     debug.error('Failed to save correction', e);
@@ -183,7 +187,7 @@ async function saveCorrection(snippet, originalIntent, correctedIntent) {
 
 async function getCorrectionsCount() {
   try {
-    const stored = await chrome.storage.local.get(CORRECTIONS_KEY);
+    const stored = await browser.storage.local.get(CORRECTIONS_KEY);
     return (stored[CORRECTIONS_KEY] || []).length;
   } catch (e) {
     return 0;
@@ -191,7 +195,7 @@ async function getCorrectionsCount() {
 }
 
 async function clearCorrections() {
-  await chrome.storage.local.remove(CORRECTIONS_KEY);
+  await browser.storage.local.remove(CORRECTIONS_KEY);
 }
 
 /**
@@ -291,7 +295,7 @@ async function classifyBatch(batchItems, platform) {
       source: platform,
       ...(mediaUrls && mediaUrls.length > 0 ? { media_urls: mediaUrls } : {})
     }));
-    const batchResults = await chrome.runtime.sendMessage({
+    const batchResults = await browser.runtime.sendMessage({
       type: 'CLASSIFY_BATCH',
       items
     });
@@ -610,7 +614,7 @@ window.IntentKeeperCore = {
 
     let connected = false;
     try {
-      const health = await chrome.runtime.sendMessage({ type: 'CHECK_HEALTH' });
+      const health = await browser.runtime.sendMessage({ type: 'CHECK_HEALTH' });
       if (!health || health.status === 'disconnected') {
         debug.error('API not available');
         createStatusBadge(adapter.platform, false);

--- a/extension/package.json
+++ b/extension/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "test": "jest",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "build": "node build.js"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -1,3 +1,7 @@
+// Cross-browser shim: Firefox exposes promise-based extension APIs on `browser`;
+// Chrome MV3 exposes them on `chrome`. Alias so this file uses promise-based `browser.*`.
+globalThis.browser = globalThis.browser || globalThis.chrome;
+
 /**
  * IntentKeeper Popup Script
  *
@@ -23,7 +27,7 @@ const elements = {
  * Load settings from storage
  */
 async function loadSettings() {
-  const stored = await chrome.storage.local.get('intentkeeper_settings');
+  const stored = await browser.storage.local.get('intentkeeper_settings');
   const settings = stored.intentkeeper_settings || {};
 
   elements.enabled.checked = settings.enabled !== false;
@@ -62,7 +66,7 @@ async function saveSettings() {
     intentEnabled
   };
 
-  await chrome.storage.local.set({ intentkeeper_settings: settings });
+  await browser.storage.local.set({ intentkeeper_settings: settings });
 }
 
 /**
@@ -76,7 +80,7 @@ async function checkHealth() {
       setTimeout(() => reject(new Error('timeout')), 5000)
     );
     const data = await Promise.race([
-      chrome.runtime.sendMessage({ type: 'CHECK_HEALTH' }),
+      browser.runtime.sendMessage({ type: 'CHECK_HEALTH' }),
       timeout
     ]);
 
@@ -115,7 +119,7 @@ elements.threshold.addEventListener('change', saveSettings);
 // --- Corrections (Phase 6.5) ---
 
 async function loadCorrectionsCount() {
-  const stored = await chrome.storage.local.get('ik_corrections');
+  const stored = await browser.storage.local.get('ik_corrections');
   const count = (stored.ik_corrections || []).length;
   const countEl = document.getElementById('corrections-count');
   const descEl = document.getElementById('corrections-desc');
@@ -128,14 +132,14 @@ async function loadCorrectionsCount() {
 }
 
 document.getElementById('clear-corrections').addEventListener('click', async () => {
-  await chrome.storage.local.remove('ik_corrections');
+  await browser.storage.local.remove('ik_corrections');
   await loadCorrectionsCount();
 });
 
 // --- Allowlist (Phase 6.2) ---
 
 async function loadAllowlist() {
-  const stored = await chrome.storage.local.get('ik_allowlist');
+  const stored = await browser.storage.local.get('ik_allowlist');
   const list = stored.ik_allowlist || [];
   const listEl = document.getElementById('allowlist-list');
   const emptyEl = document.getElementById('allowlist-empty');
@@ -161,9 +165,9 @@ async function loadAllowlist() {
     row.appendChild(btn);
     row.querySelector('button').addEventListener('click', async (e) => {
       const h = e.currentTarget.dataset.handle;
-      const s = await chrome.storage.local.get('ik_allowlist');
+      const s = await browser.storage.local.get('ik_allowlist');
       const updated = (s.ik_allowlist || []).filter(x => x !== h);
-      await chrome.storage.local.set({ ik_allowlist: updated });
+      await browser.storage.local.set({ ik_allowlist: updated });
       await loadAllowlist();
     });
     listEl.appendChild(row);
@@ -177,11 +181,11 @@ document.getElementById('allowlist-add').addEventListener('click', async () => {
   // Normalize: strip leading @ or u/
   const handle = raw.replace(/^@/, '').replace(/^u\//, '');
   if (!handle) return;
-  const stored = await chrome.storage.local.get('ik_allowlist');
+  const stored = await browser.storage.local.get('ik_allowlist');
   const list = stored.ik_allowlist || [];
   if (!list.includes(handle)) {
     list.push(handle);
-    await chrome.storage.local.set({ ik_allowlist: list });
+    await browser.storage.local.set({ ik_allowlist: list });
   }
   input.value = '';
   await loadAllowlist();


### PR DESCRIPTION
## Summary

Phase 8.2: ports the extension to Firefox MV3 without a runtime browser sniff or a vendored polyfill. The same source runs on Chromium and Firefox; a small build step emits the per-browser manifests.

## Changes

- **`extension/build.js`** (`npm run build`) - emits two bundles from the single source `manifest.json`:
  - `dist/chrome/` - MV3 `background.service_worker` (unchanged)
  - `dist/firefox/` - event-page `background.scripts` + the mandatory `browser_specific_settings.gecko.id`
- **Cross-browser API shim** in the three files that call extension APIs (`background.js`, `core/classifier.js`, `popup/popup.js`): a one-line `globalThis.browser = globalThis.browser || globalThis.chrome` alias, then `chrome.*` → `browser.*`. On Chromium `browser` aliases MV3's promise-based `chrome`; on Firefox `browser.*` is natively promise-based. Both keep the existing `onMessage` `return true` / `sendResponse` pattern, so no listener refactor.
- Docs: ROADMAP 8.2 code items checked off; CHANGELOG entry. `dist/` gitignored.

## Why the alias over `webextension-polyfill`

The roadmap floated the polyfill, but it is 40KB vendored and routes `onMessage` through a wrapper that expects promise-returning listeners - which would force a `background.js` refactor. The one-line alias is lighter, adds no dependency, and preserves the working `return true`/`sendResponse` pattern (native on both engines). Fits the project's minimal-surface ethos.

## Firefox CSP

Verified there are no inline scripts, inline event handlers, or `eval`; `popup.html` loads `popup.js` externally, so the default MV3 CSP needs no `content_security_policy` override.

## Testing

- [x] `cd extension && npm test` - **81/81 Jest tests pass, unchanged** (the alias resolves to the mocked `chrome` in jsdom)
- [x] `npm run build` produces complete `dist/chrome` and `dist/firefox` bundles with correct manifests
- [ ] Manual smoke on Firefox Developer Edition (load `dist/firefox` via `about:debugging`, check Twitter/X + YouTube + Reddit classify and render) - **human task**
- [ ] No-regression check on one Chromium browser - **human task**

## Notes

- `content.js` is unreferenced legacy (not in the manifest); left untouched and excluded from the build - flagging rather than removing.
- The Firefox add-on id (`intentkeeper@olawoyin007.github.io`) is a stable placeholder; change before AMO submission if you prefer a different namespace.
