### PR TITLE
feat: add --host, --port, --version CLI flags to intentkeeper-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to IntentKeeper are documented here.
 
 ## [Unreleased]
 
+### Added
+- `intentkeeper-server` now accepts `--host`, `--port`, and `--version` CLI
+  flags (issue #117). Host/port precedence is CLI flag > environment variable
+  (`INTENTKEEPER_HOST`/`INTENTKEEPER_PORT`) > built-in default; `--version`
+  prints the server version and exits. Running with no flags is unchanged.
+
 ### Documentation
 - `docs/model-benchmark.md`: added a 2026-07-13 full sweep (Spark/GB10 hardware,
   full 105-example set, 11 models), superseding the single-model 2026-07-10

--- a/server/api.py
+++ b/server/api.py
@@ -5,6 +5,7 @@ FastAPI server that provides content classification endpoints
 for the browser extension.
 """
 
+import argparse
 import logging
 import os
 from contextlib import asynccontextmanager
@@ -308,8 +309,20 @@ async def get_intents():
 
 def main():
     """Entry point for the server."""
-    host = os.getenv("INTENTKEEPER_HOST", "127.0.0.1")
-    port = int(os.getenv("INTENTKEEPER_PORT", "8420"))
+    parser = argparse.ArgumentParser(prog="intentkeeper-server")
+    parser.add_argument("--host", default=None, help="Bind address (overrides INTENTKEEPER_HOST)")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Port number (overrides INTENTKEEPER_PORT)",
+    )
+    parser.add_argument("--version", action="version", version=app.version)
+    args = parser.parse_args()
+
+    # Precedence: CLI flag > environment variable > built-in default.
+    host = args.host or os.getenv("INTENTKEEPER_HOST", "127.0.0.1")
+    port = args.port if args.port is not None else int(os.getenv("INTENTKEEPER_PORT", "8420"))
 
     logger.info(f"Starting IntentKeeper server on {host}:{port}")
     uvicorn.run(app, host=host, port=port)

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -11,12 +11,13 @@ Covers:
 """
 
 import asyncio
+import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from server.api import app
+from server.api import app, main
 from server.classifier import (
     MAX_CONTENT_LENGTH,
     MIN_CONTENT_LENGTH,
@@ -879,3 +880,54 @@ class TestCORSOrigins:
         from server.api import _allowed_origins
 
         assert "chrome-extension://*" not in _allowed_origins
+
+
+class TestServerEntrypoint:
+    """CLI flag handling in main() (issue #117). uvicorn.run is mocked so
+    the server never actually starts."""
+
+    def test_no_flags_uses_defaults(self):
+        with (
+            patch("server.api.uvicorn.run") as mock_run,
+            patch("sys.argv", ["intentkeeper-server"]),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            main()
+        mock_run.assert_called_once_with(app, host="127.0.0.1", port=8420)
+
+    def test_env_vars_used_as_defaults(self):
+        with (
+            patch("server.api.uvicorn.run") as mock_run,
+            patch("sys.argv", ["intentkeeper-server"]),
+            patch.dict(
+                os.environ,
+                {"INTENTKEEPER_HOST": "0.0.0.0", "INTENTKEEPER_PORT": "9000"},
+                clear=True,
+            ),
+        ):
+            main()
+        mock_run.assert_called_once_with(app, host="0.0.0.0", port=9000)
+
+    def test_flags_override_env(self):
+        with (
+            patch("server.api.uvicorn.run") as mock_run,
+            patch("sys.argv", ["intentkeeper-server", "--host", "1.2.3.4", "--port", "5555"]),
+            patch.dict(
+                os.environ,
+                {"INTENTKEEPER_HOST": "0.0.0.0", "INTENTKEEPER_PORT": "9000"},
+                clear=True,
+            ),
+        ):
+            main()
+        mock_run.assert_called_once_with(app, host="1.2.3.4", port=5555)
+
+    def test_version_flag_prints_and_exits(self, capsys):
+        with (
+            patch("server.api.uvicorn.run") as mock_run,
+            patch("sys.argv", ["intentkeeper-server", "--version"]),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 0
+        assert app.version in capsys.readouterr().out
+        mock_run.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #117. `intentkeeper-server` was configured only through environment variables. This adds three standard CLI flags to `main()`:

- `--host` - bind address (overrides `INTENTKEEPER_HOST`)
- `--port` - port number (overrides `INTENTKEEPER_PORT`)
- `--version` - prints the server version (`app.version`) and exits 0 without starting the server

Host/port precedence is **CLI flag > environment variable > built-in default** (`127.0.0.1:8420`). Running with no flags is byte-for-byte the same behaviour as before.

## Changes

- `server/api.py`: `argparse` handling in `main()` for the three flags.
- `tests/test_classifier.py`: `TestServerEntrypoint` - four tests (no-flags defaults, env-as-defaults, flags-beat-env, `--version` prints-and-exits), each with a mocked `uvicorn.run` so the server never starts.
- `CHANGELOG.md`: `[Unreleased]` Added entry.

## Related Issues

Closes #117.

## Testing

- [x] `pytest tests/ -q` - 97 passed, coverage 86%
- [x] `cd extension && npm test` - 81 passed
- [x] `black --check` and `ruff check` pass
- [x] Manually exercised the real console script: `intentkeeper-server --version` prints `0.6.0` and exits 0; `--help` lists all three flags
