### PR TITLE
docs: remove hardware-identifying detail from benchmark notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ All notable changes to IntentKeeper are documented here.
   prints the server version and exits. Running with no flags is unchanged.
 
 ### Documentation
-- `docs/model-benchmark.md`: added a 2026-07-13 full sweep (Spark/GB10 hardware,
-  full 105-example set, 11 models), superseding the single-model 2026-07-10
+- `docs/model-benchmark.md`: added a 2026-07-13 full sweep (full 105-example
+  set, 11 models), superseding the single-model 2026-07-10
   spot-check. Confirms `llama3.1:8b` as the sweet spot (96% at 8 GB);
   `qwen2.5:14b-instruct-q4_K_M` edges it at 97%. `README.md` recommended-models
   table updated to the fresh figures (was the 98-example 2026-06-14 set).

--- a/docs/model-benchmark.md
+++ b/docs/model-benchmark.md
@@ -5,7 +5,7 @@ Higher accuracy = fewer wrong classifications on real social media content.
 
 _Last full benchmark: 2026-04-26 14:24 UTC, on the then-80-example set._
 
-> **2026-07-13 spot-check (Spark/GB10 hardware, full 105-example set, 11 models).**
+> **2026-07-13 spot-check (full 105-example set, 11 models).**
 > Supersedes the single-model 2026-07-10 spot-check below with a full sweep.
 >
 > | Model | Min VRAM | Accuracy |


### PR DESCRIPTION
## Summary

Removes hardware-identifying detail from public docs. The 2026-07-13 benchmark
note named the specific machine ("Spark/GB10 hardware") in two places:

- `docs/model-benchmark.md` - the spot-check callout.
- `CHANGELOG.md` - the Documentation entry describing that note.

The machine is private context, not project documentation. The benchmark facts
that matter - example count, model list, Min VRAM tier, accuracy - are unchanged.
This mirrors the same scrub done on empathySync (#178).

## Testing

- [x] `grep -ri "kingdavid|GB10|spark|RTX|4070|119G|dgx|nvidia"` over
      `README.md`, `CHANGELOG.md`, `docs/` - clean, no matches.
- Docs-only change; no code touched.
