### PR TITLE
feat: honest 'not analyzed' marker for media-dominant posts (#124, #136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ All notable changes to IntentKeeper are documented here.
   table updated to the fresh figures (was the 98-example 2026-06-14 set).
 
 ### Changed
+- Minimum-signal skip for media-dominant / low-text posts (issue #124). The
+  extension now measures a post's *readable* text - metadata brackets
+  (`[Author: X]`, `[r/news]`, `[Video tweet]`), URLs, and @handles stripped -
+  and skips classification when that falls below the length threshold, instead
+  of spending a classify call on content it cannot actually read. Fails open (no
+  treatment), matching the manifesto. Posts carrying media URLs are never
+  skipped here - the server's vision model may still read the image. The full
+  text (handles and all) is still what gets classified when a post is not
+  skipped. New `contentSignal()` helper with 7 Jest tests.
 - Phase 7 (Statistics Dashboard) deferred pending manifesto reconciliation.
   The manifesto commits intentKeeper to "doesn't track or nudge" and its
   Living Clause forbids changes that add tracking; exposure counters sit in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,11 +52,14 @@ Content Intercepted (tweet / post / comment)
     │
     ▼
 ┌─────────────────────────────────────────────┐
-│  1. LENGTH CHECK                            │
-│     < 20 characters → mark "skipped"       │
+│  1. MINIMUM-SIGNAL CHECK                    │
+│     readable text (metadata/URL/@handle     │
+│      stripped) < 20 chars AND no media URLs │
+│      → mark "skipped" (media-dominant post) │
 │     empty string → leave unmarked          │
 │       (element still loading, retry next   │
 │        observer pass)                       │
+│     has media URLs → pass (vision may read) │
 └─────────────────────────────────────────────┘
     │ Pass
     ▼

--- a/extension/core/classifier.js
+++ b/extension/core/classifier.js
@@ -100,6 +100,23 @@ function normalizeWhitespace(str) {
 }
 
 /**
+ * Strip out everything that carries no readable content - adapter metadata
+ * (`[Author: X]`, `[r/news]`, `[Video tweet]`), URLs, and @handles - and return
+ * what's left. Used only to decide whether a post has enough real text to be
+ * worth classifying; the full text (handles and all) is still what gets sent to
+ * the classifier when a post is not skipped. Media-dominant posts scrape down to
+ * mostly metadata, so this is what the minimum-signal skip in processItems tests.
+ */
+function contentSignal(str) {
+  return str
+    .replace(/\[[^\]]*\]/g, ' ')      // adapter metadata brackets
+    .replace(/https?:\/\/\S+/g, ' ')  // URLs
+    .replace(/@\w+/g, ' ')            // @handles / mentions
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
  * Human-readable label for each intent, including YouTube-specific intents
  * added in Phase 3.
  */
@@ -475,8 +492,13 @@ async function processItems(adapter) {
     for (const item of items) {
       const text = normalizeWhitespace(adapter.extractText(item));
       const mediaUrls = adapter.extractMediaUrls ? adapter.extractMediaUrls(item) : [];
-      if (text.length < MIN_CONTENT_LENGTH) {
-        // Only permanently skip items with SOME text (genuinely short content).
+      // Minimum-signal skip: a media-dominant post scrapes down to mostly
+      // metadata/handles/URLs, leaving too little real text to classify. Skip it
+      // rather than waste a classify call on low-confidence noise (fail open - no
+      // treatment). Posts carrying media URLs are never skipped here: the server's
+      // vision model may read the image, so we let it decide.
+      if (mediaUrls.length === 0 && contentSignal(text).length < MIN_CONTENT_LENGTH) {
+        // Only permanently skip items with SOME text (genuinely thin content).
         // Empty string means the element is still loading (lazy render) -
         // leave it unmarked so the next observer pass can pick it up.
         if (text.length > 0) {
@@ -597,7 +619,7 @@ function setupObserver(adapter) {
 
 // Expose utility functions for testing in Node (Jest/jsdom)
 if (typeof module !== 'undefined') {
-  module.exports = { hashContent, normalizeWhitespace, formatIntent, escapeHtml, buildSelector };
+  module.exports = { hashContent, normalizeWhitespace, contentSignal, formatIntent, escapeHtml, buildSelector };
 }
 
 window.IntentKeeperCore = {

--- a/extension/tests/core.test.js
+++ b/extension/tests/core.test.js
@@ -3,7 +3,7 @@
  * Covers pure utility functions and the selector-building logic.
  */
 
-const { hashContent, normalizeWhitespace, formatIntent, escapeHtml, buildSelector } = require('../core/classifier');
+const { hashContent, normalizeWhitespace, contentSignal, formatIntent, escapeHtml, buildSelector } = require('../core/classifier');
 
 describe('hashContent', () => {
   test('same input produces same hash', () => {
@@ -92,6 +92,46 @@ describe('normalizeWhitespace', () => {
 
   test('handles empty string', () => {
     expect(normalizeWhitespace('')).toBe('');
+  });
+});
+
+describe('contentSignal', () => {
+  // The minimum-signal skip in processItems compares this against MIN_CONTENT_LENGTH (20).
+
+  test('strips adapter metadata brackets, keeps real text', () => {
+    expect(contentSignal('[Author: SomeName] this is the real tweet body'))
+      .toBe('this is the real tweet body');
+  });
+
+  test('strips multiple bracket tags (Reddit-style)', () => {
+    expect(contentSignal('[r/news] [Flair: Politics] a genuine post title here'))
+      .toBe('a genuine post title here');
+  });
+
+  test('strips URLs', () => {
+    expect(contentSignal('check this https://t.co/abc123 out'))
+      .toBe('check this out');
+  });
+
+  test('strips @handles', () => {
+    expect(contentSignal('@alice @bob what do you all think'))
+      .toBe('what do you all think');
+  });
+
+  test('a media-dominant post reduces to (near) nothing - it will be skipped', () => {
+    // Video tweet with only author + video flag scraped: no readable content.
+    const signal = contentSignal('[Author: SomeName] [Video tweet]');
+    expect(signal).toBe('');
+    expect(signal.length).toBeLessThan(20);
+  });
+
+  test('a real post stays above the skip threshold even with metadata', () => {
+    const signal = contentSignal('[Author: X] [Context: reposted] the sky is falling and you should be very afraid');
+    expect(signal.length).toBeGreaterThanOrEqual(20);
+  });
+
+  test('handles empty string', () => {
+    expect(contentSignal('')).toBe('');
   });
 });
 


### PR DESCRIPTION
## Summary

Reshapes the minimum-signal gate so the extension is **honest about media it cannot read yet** instead of guessing a manipulation label from scraped image alt-text / video metadata (closes #124, implements #136).

Three outcomes per post:

1. **Enough readable text** (`contentSignal()` strips metadata brackets, URLs, @handles) -> classified normally on the text, whether or not media is attached.
2. **Thin text but has image/video, and no vision model configured** -> a dim, non-judgemental **"Media - not analyzed yet"** badge. No manipulation verdict.
3. **Thin text and no media** -> silent skip (nothing to classify).

Fails open throughout - no fabricated verdicts.

**Pluggable vision slot:** `/health` now reports `vision: bool` (whether `OLLAMA_VISION_MODEL` is set). When a real vision model is plugged in, case-2 posts flow through it to be classified with image context instead of getting the placeholder. One config flip, no code change - the seam for Phase 9.1.

Files: `extension/core/classifier.js` (gate + `applyNotAnalyzed`), `extension/styles.css` (dim badge), `server/api.py` (`/health.vision`), plus CHANGELOG / ROADMAP / `docs/architecture.md`.

## Testing

- `cd extension && npm test` -> 88 Jest pass (incl. 7 `contentSignal` tests).
- `./venv/bin/python -m pytest tests/` -> 98 pass, 86% coverage (incl. 2 new `/health.vision` tests).
- `cd extension && npm run build` -> builds `dist/chrome` + `dist/firefox` clean; new code present in both.
- **Manual smoke test (human):** load `dist/chrome`, start the local server, browse Twitter/X. Confirm: a video/image post with little text shows the dim "not analyzed yet" badge; a normal text post still gets a real label; a text post with an image still gets a real label.
