### PR TITLE
test: cover background.js and popup.js (issue #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ All notable changes to IntentKeeper are documented here.
   native on both engines. All 81 Jest tests pass unchanged. Manual Firefox
   Developer Edition smoke test and AMO submission remain (human tasks).
 
+### Tests
+- Extension test coverage for the two untested JS surfaces (issue #17). Added
+  `extension/tests/background.test.js` (17 tests: API proxy for `/classify` and
+  `/classify/batch`, health-check fail-open, correction loading/formatting,
+  batch enrichment with user corrections, and the status badge) and
+  `extension/tests/popup.test.js` (12 tests: settings load/save round-trip,
+  connection-status rendering, correction count, and allowlist add with
+  `@`/`u/` normalization). Both files use a small `module.exports` guard added
+  to `background.js` and `popup.js` (same pattern already in `core/classifier.js`)
+  so their functions are importable under Node; browser behaviour is unchanged.
+  `content.js` was not covered - it has been dead code since Phase 3.5 (the
+  content script split into `core/classifier.js` + `platforms/*`). Jest 110 pass.
+
 ### Documentation
 - `docs/model-benchmark.md`: added a 2026-07-13 full sweep (full 105-example
   set, 11 models), superseding the single-model 2026-07-10

--- a/extension/background.js
+++ b/extension/background.js
@@ -191,6 +191,21 @@ async function updateBadge() {
   }
 }
 
-// Check health on startup and periodically
-updateBadge();
-setInterval(updateBadge, HEALTH_CHECK_INTERVAL);
+// Check health on startup and periodically. Skipped under Node (Jest) so
+// importing this module for unit tests doesn't fire a real fetch or timer.
+if (typeof module === 'undefined') {
+  updateBadge();
+  setInterval(updateBadge, HEALTH_CHECK_INTERVAL);
+}
+
+// Expose functions for testing in Node (Jest). No-op in the browser worker.
+if (typeof module !== 'undefined') {
+  module.exports = {
+    checkApiHealth,
+    classifyContent,
+    classifyBatch,
+    loadCorrectionsForPrompt,
+    updateBadge,
+    DEFAULT_SETTINGS,
+  };
+}

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -195,8 +195,24 @@ document.getElementById('allowlist-input').addEventListener('keydown', (e) => {
   if (e.key === 'Enter') document.getElementById('allowlist-add').click();
 });
 
-// Initialize
-loadSettings();
-checkHealth();
-loadCorrectionsCount();
-loadAllowlist();
+// Initialize. Guarded so importing this file under Node (Jest) doesn't fire the
+// initial load calls before a test has set up the DOM / mocks; the browser popup
+// (no `module`) runs them as before.
+if (typeof module === 'undefined') {
+  loadSettings();
+  checkHealth();
+  loadCorrectionsCount();
+  loadAllowlist();
+}
+
+// Expose functions for testing in Node (Jest). No-op in the browser popup.
+if (typeof module !== 'undefined') {
+  module.exports = {
+    loadSettings,
+    saveSettings,
+    checkHealth,
+    loadCorrectionsCount,
+    loadAllowlist,
+    INTENT_KEYS,
+  };
+}

--- a/extension/tests/background.test.js
+++ b/extension/tests/background.test.js
@@ -1,0 +1,173 @@
+/**
+ * Tests for extension/background.js - the service worker's logic layer:
+ * API proxying (classify / batch / health), correction loading, and the badge.
+ *
+ * The worker's fetch calls are mocked; chrome.* is mocked in tests/setup.js.
+ */
+
+const {
+  checkApiHealth,
+  classifyContent,
+  classifyBatch,
+  loadCorrectionsForPrompt,
+  updateBadge,
+  DEFAULT_SETTINGS,
+} = require('../background');
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+  chrome.storage.local.get.mockResolvedValue({});
+  chrome.action.setBadgeText.mockClear();
+  chrome.action.setBadgeBackgroundColor.mockClear();
+});
+
+describe('checkApiHealth', () => {
+  test('returns the parsed health payload when the server responds', async () => {
+    const payload = { status: 'ok', ollama_connected: true, model: 'llama3.1:8b' };
+    fetch.mockResolvedValue({ json: async () => payload });
+
+    await expect(checkApiHealth()).resolves.toEqual(payload);
+    expect(fetch).toHaveBeenCalledWith('http://localhost:8420/health');
+  });
+
+  test('fails open to a disconnected payload when the fetch throws', async () => {
+    fetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(checkApiHealth()).resolves.toEqual({
+      status: 'disconnected',
+      ollama_connected: false,
+      model: 'none',
+    });
+  });
+});
+
+describe('classifyContent', () => {
+  test('POSTs the content to /classify and returns the JSON result', async () => {
+    const result = { intent: 'ragebait', confidence: 0.9, action: 'blur' };
+    fetch.mockResolvedValue({ ok: true, json: async () => result });
+
+    await expect(classifyContent('some tweet', 'twitter')).resolves.toEqual(result);
+    const [url, opts] = fetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8420/classify');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ content: 'some tweet', source: 'twitter' });
+  });
+
+  test('defaults the source to twitter when none is given', async () => {
+    fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+    await classifyContent('x');
+    expect(JSON.parse(fetch.mock.calls[0][1].body).source).toBe('twitter');
+  });
+
+  test('returns null on a non-ok response', async () => {
+    fetch.mockResolvedValue({ ok: false, status: 500 });
+    await expect(classifyContent('x', 'twitter')).resolves.toBeNull();
+  });
+
+  test('returns null when the fetch throws', async () => {
+    fetch.mockRejectedValue(new Error('network'));
+    await expect(classifyContent('x', 'twitter')).resolves.toBeNull();
+  });
+});
+
+describe('loadCorrectionsForPrompt', () => {
+  test('maps stored corrections to the server field names', async () => {
+    chrome.storage.local.get.mockResolvedValue({
+      ik_corrections: [
+        { snippet: 'a', originalIntent: 'hype', correctedIntent: 'genuine', timestamp: 1 },
+      ],
+    });
+
+    await expect(loadCorrectionsForPrompt()).resolves.toEqual([
+      { snippet: 'a', original_intent: 'hype', corrected_intent: 'genuine' },
+    ]);
+  });
+
+  test('returns only the 5 most recent corrections', async () => {
+    const many = Array.from({ length: 8 }, (_, i) => ({
+      snippet: `s${i}`, originalIntent: 'hype', correctedIntent: 'genuine',
+    }));
+    chrome.storage.local.get.mockResolvedValue({ ik_corrections: many });
+
+    const result = await loadCorrectionsForPrompt();
+    expect(result).toHaveLength(5);
+    expect(result[0].snippet).toBe('s3'); // last 5 -> s3..s7
+    expect(result[4].snippet).toBe('s7');
+  });
+
+  test('returns an empty array when there are no corrections', async () => {
+    chrome.storage.local.get.mockResolvedValue({});
+    await expect(loadCorrectionsForPrompt()).resolves.toEqual([]);
+  });
+
+  test('returns an empty array when storage throws', async () => {
+    chrome.storage.local.get.mockRejectedValue(new Error('storage'));
+    await expect(loadCorrectionsForPrompt()).resolves.toEqual([]);
+  });
+});
+
+describe('classifyBatch', () => {
+  test('POSTs items to /classify/batch and returns data.results', async () => {
+    const results = [{ intent: 'hype' }, { intent: 'genuine' }];
+    fetch.mockResolvedValue({ ok: true, json: async () => ({ results }) });
+
+    const out = await classifyBatch([{ content: 'a' }, { content: 'b' }]);
+    expect(out).toEqual(results);
+    expect(fetch.mock.calls[0][0]).toBe('http://localhost:8420/classify/batch');
+  });
+
+  test('enriches each item with user_corrections when corrections exist', async () => {
+    chrome.storage.local.get.mockResolvedValue({
+      ik_corrections: [{ snippet: 'a', originalIntent: 'hype', correctedIntent: 'genuine' }],
+    });
+    fetch.mockResolvedValue({ ok: true, json: async () => ({ results: [] }) });
+
+    await classifyBatch([{ content: 'a' }]);
+    const sent = JSON.parse(fetch.mock.calls[0][1].body);
+    expect(sent.items[0].user_corrections).toEqual([
+      { snippet: 'a', original_intent: 'hype', corrected_intent: 'genuine' },
+    ]);
+  });
+
+  test('omits user_corrections when there are none', async () => {
+    chrome.storage.local.get.mockResolvedValue({});
+    fetch.mockResolvedValue({ ok: true, json: async () => ({ results: [] }) });
+
+    await classifyBatch([{ content: 'a' }]);
+    const sent = JSON.parse(fetch.mock.calls[0][1].body);
+    expect(sent.items[0]).not.toHaveProperty('user_corrections');
+  });
+
+  test('returns null on a non-ok response', async () => {
+    fetch.mockResolvedValue({ ok: false, status: 502 });
+    await expect(classifyBatch([{ content: 'a' }])).resolves.toBeNull();
+  });
+});
+
+describe('updateBadge', () => {
+  test('clears the badge and goes green when the server is ok', async () => {
+    fetch.mockResolvedValue({ json: async () => ({ status: 'ok' }) });
+
+    await updateBadge();
+    expect(chrome.action.setBadgeText).toHaveBeenCalledWith({ text: '' });
+    expect(chrome.action.setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#4CAF50' });
+  });
+
+  test('shows a red "!" when the server is unreachable', async () => {
+    fetch.mockRejectedValue(new Error('down'));
+
+    await updateBadge();
+    expect(chrome.action.setBadgeText).toHaveBeenCalledWith({ text: '!' });
+    expect(chrome.action.setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#f44336' });
+  });
+});
+
+describe('DEFAULT_SETTINGS', () => {
+  test('ships every intent toggle enabled by default', () => {
+    expect(DEFAULT_SETTINGS.enabled).toBe(true);
+    for (const key of ['ragebait', 'fearmongering', 'hype', 'engagement_bait', 'divisive']) {
+      expect(DEFAULT_SETTINGS.intentEnabled[key]).toBe(true);
+    }
+  });
+});

--- a/extension/tests/popup.test.js
+++ b/extension/tests/popup.test.js
@@ -1,0 +1,170 @@
+/**
+ * Tests for extension/popup/popup.js - settings load/save round-trip, the
+ * connection-status rendering, correction count, and allowlist add/normalize.
+ *
+ * popup.js reads DOM elements at load, so each test rebuilds the popup DOM,
+ * resets the module cache, then requires it fresh. chrome.* is mocked in
+ * tests/setup.js.
+ */
+
+// Minimal DOM matching the IDs popup.js reads/writes.
+const FIXTURE = `
+  <input type="checkbox" id="enabled">
+  <input type="checkbox" id="showTags">
+  <input type="checkbox" id="blurRagebait">
+  <input type="checkbox" id="hideEngagementBait">
+  <input type="range" id="threshold" min="0" max="100" value="60">
+  <span id="thresholdValue"></span>
+  <div id="status"></div>
+  <span id="status-text"></span>
+  <input type="checkbox" id="intent-ragebait">
+  <input type="checkbox" id="intent-fearmongering">
+  <input type="checkbox" id="intent-hype">
+  <input type="checkbox" id="intent-engagement_bait">
+  <input type="checkbox" id="intent-divisive">
+  <span id="corrections-count"></span>
+  <span id="corrections-desc"></span>
+  <button id="clear-corrections"></button>
+  <div id="allowlist-list"></div>
+  <div id="allowlist-empty"></div>
+  <button id="allowlist-add"></button>
+  <input id="allowlist-input">
+`;
+
+let popup;
+
+beforeEach(() => {
+  document.body.innerHTML = FIXTURE;
+  chrome.storage.local.get.mockReset().mockResolvedValue({});
+  chrome.storage.local.set.mockReset().mockResolvedValue({});
+  chrome.storage.local.remove = jest.fn().mockResolvedValue({});
+  chrome.runtime.sendMessage.mockReset();
+  jest.resetModules();
+  popup = require('../popup/popup');
+});
+
+describe('loadSettings', () => {
+  test('reflects stored settings into the controls', async () => {
+    chrome.storage.local.get.mockResolvedValue({
+      intentkeeper_settings: {
+        enabled: false,
+        showTags: true,
+        manipulationThreshold: 0.8,
+        intentEnabled: { ragebait: false },
+      },
+    });
+
+    await popup.loadSettings();
+
+    expect(document.getElementById('enabled').checked).toBe(false);
+    expect(document.getElementById('showTags').checked).toBe(true);
+    expect(document.getElementById('threshold').value).toBe('80');
+    expect(document.getElementById('thresholdValue').textContent).toBe('80%');
+    expect(document.getElementById('intent-ragebait').checked).toBe(false);
+    // A key absent from stored intentEnabled defaults to enabled.
+    expect(document.getElementById('intent-hype').checked).toBe(true);
+  });
+
+  test('defaults to enabled / 60% when storage is empty', async () => {
+    await popup.loadSettings();
+    expect(document.getElementById('enabled').checked).toBe(true);
+    expect(document.getElementById('threshold').value).toBe('60');
+    expect(document.getElementById('thresholdValue').textContent).toBe('60%');
+  });
+});
+
+describe('saveSettings', () => {
+  test('writes the current control state to storage', async () => {
+    document.getElementById('enabled').checked = true;
+    document.getElementById('showTags').checked = false;
+    document.getElementById('blurRagebait').checked = true;
+    document.getElementById('hideEngagementBait').checked = false;
+    document.getElementById('threshold').value = '75';
+    document.getElementById('intent-ragebait').checked = true;
+    document.getElementById('intent-divisive').checked = false;
+
+    await popup.saveSettings();
+
+    expect(chrome.storage.local.set).toHaveBeenCalledTimes(1);
+    const saved = chrome.storage.local.set.mock.calls[0][0].intentkeeper_settings;
+    expect(saved.enabled).toBe(true);
+    expect(saved.showTags).toBe(false);
+    expect(saved.manipulationThreshold).toBe(0.75);
+    expect(saved.intentEnabled.divisive).toBe(false);
+    expect(saved.intentEnabled.ragebait).toBe(true);
+  });
+
+  test('a checkbox change event triggers a save', async () => {
+    const cb = document.getElementById('enabled');
+    cb.dispatchEvent(new Event('change'));
+    await Promise.resolve();
+    expect(chrome.storage.local.set).toHaveBeenCalled();
+  });
+});
+
+describe('checkHealth', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  test('shows Connected with the model when the server is ok', async () => {
+    chrome.runtime.sendMessage.mockResolvedValue({ status: 'ok', model: 'llama3.1:8b' });
+    await popup.checkHealth();
+    expect(document.getElementById('status-text').textContent).toBe('Connected (llama3.1:8b)');
+    expect(document.getElementById('status').className).toBe('status connected');
+  });
+
+  test('shows Ollama not connected when the server is up but Ollama is down', async () => {
+    chrome.runtime.sendMessage.mockResolvedValue({ status: 'disconnected', ollama_connected: false });
+    await popup.checkHealth();
+    expect(document.getElementById('status-text').textContent).toBe('Ollama not connected');
+  });
+
+  test('shows Server not running when the message rejects', async () => {
+    chrome.runtime.sendMessage.mockRejectedValue(new Error('no worker'));
+    await popup.checkHealth();
+    expect(document.getElementById('status-text').textContent).toBe('Server not running');
+  });
+});
+
+describe('loadCorrectionsCount', () => {
+  test('renders a pluralized description for multiple corrections', async () => {
+    chrome.storage.local.get.mockResolvedValue({ ik_corrections: [{}, {}] });
+    await popup.loadCorrectionsCount();
+    expect(document.getElementById('corrections-count').textContent).toBe('2');
+    expect(document.getElementById('corrections-desc').textContent).toContain('2 corrections');
+  });
+
+  test('renders the empty hint when there are no corrections', async () => {
+    chrome.storage.local.get.mockResolvedValue({});
+    await popup.loadCorrectionsCount();
+    expect(document.getElementById('corrections-count').textContent).toBe('0');
+    expect(document.getElementById('corrections-desc').textContent).toContain('Hover a tag');
+  });
+});
+
+describe('allowlist add', () => {
+  test('strips a leading @ and lowercases before storing', async () => {
+    document.getElementById('allowlist-input').value = '@Alice';
+    document.getElementById('allowlist-add').dispatchEvent(new Event('click'));
+    await Promise.resolve(); await Promise.resolve();
+
+    const call = chrome.storage.local.set.mock.calls.find(c => c[0].ik_allowlist);
+    expect(call[0].ik_allowlist).toEqual(['alice']);
+  });
+
+  test('strips a leading u/ prefix', async () => {
+    document.getElementById('allowlist-input').value = 'u/Bob';
+    document.getElementById('allowlist-add').dispatchEvent(new Event('click'));
+    await Promise.resolve(); await Promise.resolve();
+
+    const call = chrome.storage.local.set.mock.calls.find(c => c[0].ik_allowlist);
+    expect(call[0].ik_allowlist).toEqual(['bob']);
+  });
+
+  test('does nothing on empty input', async () => {
+    document.getElementById('allowlist-input').value = '   ';
+    document.getElementById('allowlist-add').dispatchEvent(new Event('click'));
+    await Promise.resolve();
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #17.

## Summary
The extension's logic layer had no test coverage. This adds it for the two untested JS surfaces:

- **`background.js`** (17 tests): the `/classify` and `/classify/batch` proxy calls, health-check fail-open, correction loading + server-field formatting, batch enrichment with user corrections, and the status badge (green ok / red `!`).
- **`popup.js`** (12 tests): settings load/save round-trip, connection-status rendering (Connected / Ollama down / server not running), correction count + pluralization, and allowlist add with `@`/`u/` handle normalization.

Both files get a tiny `module.exports` guard (the same pattern already in `core/classifier.js`) so their functions are importable under Node. Browser behaviour is unchanged - the guards are `typeof module` checks, and the load-time init/polling only runs when there is no `module` (i.e. in the browser).

**Note on `content.js`:** the issue lists it, but it has been dead code since Phase 3.5 - the content script was split into `core/classifier.js` + `platforms/*` (the file header says so, and `manifest.json` doesn't load it). So it is intentionally not covered.

## Testing
- `cd extension && npm test` - 110 pass (81 existing + 17 + 12 new)
- `pytest tests/ -q` - 97 pass (server untouched)