### PR TITLE
docs: Chrome Web Store submission kit (Phase 8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to IntentKeeper are documented here.
 ## [Unreleased]
 
 ### Added
+- Chrome Web Store submission kit (Phase 8.1). `store/CHROME_WEB_STORE.md`
+  (listing copy, single-purpose statement, permission justifications,
+  data-safety answers, reviewer notes), `PRIVACY.md` (privacy policy), and
+  `store/SUBMISSION_CHECKLIST.md` (the human steps: dev account, $5 fee,
+  screenshots, submit). Same kit carries over to the Edge Add-ons store.
 - `intentkeeper-server` now accepts `--host`, `--port`, and `--version` CLI
   flags (issue #117). Host/port precedence is CLI flag > environment variable
   (`INTENTKEEPER_HOST`/`INTENTKEEPER_PORT`) > built-in default; `--version`
@@ -30,6 +35,11 @@ All notable changes to IntentKeeper are documented here.
   table updated to the fresh figures (was the 98-example 2026-06-14 set).
 
 ### Changed
+- Removed the unused `activeTab` permission from `extension/manifest.json`. It
+  was declared but never used (no `tabs`/`activeTab` call anywhere), and unused
+  permissions are a Chrome Web Store review risk and a weaker privacy story. The
+  extension now requests only `storage` plus the localhost host permission. No
+  behaviour change; build emits it out of both `dist/chrome` and `dist/firefox`.
 - Phase 7 (Statistics Dashboard) deferred pending manifesto reconciliation.
   The manifesto commits intentKeeper to "doesn't track or nudge" and its
   Living Clause forbids changes that add tracking; exposure counters sit in

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,71 @@
+# Privacy Policy - intentKeeper
+
+_Last updated: 2026-07-26_
+
+intentKeeper is built on one promise: **your data never leaves your machine.**
+This policy describes exactly what the browser extension does and does not do
+with your information.
+
+## The short version
+
+- intentKeeper does **not** collect, transmit, sell, or share any personal data.
+- There are **no analytics, no telemetry, no tracking, and no remote servers**
+  operated by us.
+- The only network request the extension makes is to a classification server
+  running on **your own computer** (`http://localhost:8420`), which you install
+  and run yourself.
+- Everything you configure is stored **locally in your browser** and can be
+  deleted at any time by removing the extension.
+
+## What the extension accesses, and why
+
+**Page content on supported sites (Twitter/X, YouTube, Reddit).**
+To do its job, intentKeeper reads the text of posts, titles, and comments on the
+pages you visit on these sites. This text is sent **only** to the classification
+server on your own computer to be labeled (for example, "ragebait" or
+"genuine"). It is used in that instant to decide whether to blur, tag, or hide
+the item. It is **not** stored, logged, or transmitted anywhere else.
+
+**Local browser storage (`storage` permission).**
+The extension saves your settings in your browser's local storage on your own
+device:
+
+- your on/off toggles and sensitivity slider,
+- your per-intent preferences (e.g. "show divisive, hide ragebait"),
+- your "trusted accounts" allowlist (handles you choose to never filter),
+- your local corrections (when you re-label an item to teach your own copy).
+
+None of this is transmitted off your device. Uninstalling the extension removes
+it.
+
+## What we do NOT do
+
+- We do **not** run any server that receives your data. The `localhost` server
+  is yours.
+- We do **not** use cookies, advertising identifiers, fingerprinting, or any
+  cross-site tracking.
+- We do **not** collect browsing history, account credentials, or personal
+  identifiers.
+- We do **not** build a profile of you. There is no engagement optimization and
+  nothing is measured about your behavior.
+
+## Data retention and deletion
+
+Because nothing is collected by us, there is nothing for us to retain or delete.
+The only data that exists is the settings stored locally in your browser, which
+you control and can clear at any time (remove the extension, or use the popup's
+"Clear" buttons for corrections and allowlist entries).
+
+## Children's privacy
+
+intentKeeper does not knowingly collect any data from anyone, including children.
+
+## Changes to this policy
+
+If this policy changes, the updated version will be published in this repository
+with a new "Last updated" date.
+
+## Contact
+
+Questions about privacy can be raised as an issue on the project repository:
+https://github.com/Olawoyin007/intentKeeper

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -344,8 +344,13 @@ Chrome, Brave, Edge, and Opera all run Chromium and support Manifest V3 natively
 - [x] Brave Private Network Access (PNA) support: `PrivateNetworkAccessMiddleware` added to API server - responds with `Access-Control-Allow-Private-Network: true` when Brave's PNA preflight fires. 3 tests in `TestPrivateNetworkAccessMiddleware`.
 - [x] Tested on Microsoft Edge - `chrome.*` API aliases work as expected
 - [x] Tested on Opera - works without modification
-- [ ] Submit to Chrome Web Store (covers Brave and Opera users via CWS) - **human task**: requires developer account, payment, and store listing; an agent prepares the zip + listing text, the owner submits
-- [ ] Submit to Microsoft Edge Add-ons store - **human task**, same split
+- [x] Store submission kit prepared: listing copy, permission justifications,
+      data-safety answers, and reviewer notes in `store/CHROME_WEB_STORE.md`;
+      privacy policy in `PRIVACY.md`; step-by-step guide in
+      `store/SUBMISSION_CHECKLIST.md`. Unused `activeTab` permission removed so
+      the listing requests only `storage` + the localhost host permission.
+- [ ] Submit to Chrome Web Store (covers Brave and Opera users via CWS) - **human task**: dev account + $5 fee, screenshots, and the actual submit. Kit ready in `store/`.
+- [ ] Submit to Microsoft Edge Add-ons store - **human task**, same kit carries over
 - [ ] Document installation instructions for each browser
 
 ### 8.2 Firefox

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,8 +4,7 @@
   "version": "0.6.0",
   "description": "A digital bodyguard for your mind - filters content by intent",
   "permissions": [
-    "storage",
-    "activeTab"
+    "storage"
   ],
   "host_permissions": [
     "http://localhost:8420/*",

--- a/store/CHROME_WEB_STORE.md
+++ b/store/CHROME_WEB_STORE.md
@@ -1,0 +1,132 @@
+# Chrome Web Store - Listing Copy
+
+Ready-to-paste text for the Chrome Web Store developer dashboard. Copy each
+field into the matching box. Anything marked **[human]** needs a person (an
+image, an account, a payment, a hosted URL).
+
+---
+
+## Product name
+
+```
+intentKeeper
+```
+
+## Summary (short description - max 132 characters)
+
+```
+See the manipulation behind your feed. Local AI flags ragebait, hype and fear on Twitter, YouTube and Reddit. Nothing leaves your device.
+```
+
+_(131 characters - check the live counter; trim "and Reddit" if it complains.)_
+
+## Category
+
+```
+Productivity
+```
+
+## Language
+
+```
+English (United States)
+```
+
+## Detailed description
+
+```
+You open Twitter to check one thing. Forty minutes later you're exhausted and angry about something you don't even care about. intentKeeper shows you what's doing that - on Twitter/X, YouTube, and Reddit - before it lands.
+
+It reads posts, titles, and comments and flags the ones built to manipulate you: ragebait, fearmongering, hype, engagement bait, and divisive framing. It judges content by the PATTERNS it uses, not the topics it covers - so it never takes a side on what you're allowed to read. You decide what happens to flagged items: blur it, tag it, or hide it.
+
+WHY IT'S DIFFERENT
+
+- Runs entirely on your own hardware. Classification happens on a small AI model (via Ollama) on your computer. There is no cloud, no account, and no data leaving your machine.
+- No tracking, no telemetry, no engagement metrics. The extension has nothing to sell and measures nothing about you.
+- You stay in control. Per-intent toggles ("show divisive, hide ragebait"), a sensitivity slider, a trusted-accounts allowlist, and the ability to correct any label - all stored locally.
+
+IMPORTANT: REQUIRES A FREE LOCAL SERVER
+
+intentKeeper is local-first by design. The extension talks to a small classification server that YOU run on your own computer (it ships free and open-source with the project). Without it running, the extension does nothing - it has no remote fallback on purpose, because "no data leaves your device" is the whole point.
+
+One-time setup (about 5 minutes): install Ollama, install the intentKeeper server, start it. Full instructions:
+https://github.com/Olawoyin007/intentKeeper
+
+HOW IT WORKS
+
+1. You browse Twitter/X, YouTube, or Reddit as normal.
+2. The extension sends each post's text to your local server.
+3. The server labels it (ragebait, hype, genuine, etc.) using a local AI model.
+4. Based on your settings, the item is blurred, tagged, or hidden - or passes through untouched.
+
+Open-source (MIT). Built on the principle that software should protect your attention, not harvest it.
+```
+
+## Privacy practices tab
+
+### Single purpose description
+
+```
+intentKeeper has one purpose: to detect manipulative intent (such as ragebait, fearmongering, and engagement bait) in social media content on Twitter/X, YouTube, and Reddit, and let the user blur, tag, or hide it. All classification is performed by a server on the user's own machine.
+```
+
+### Permission justifications
+
+**`storage`**
+```
+Stores the user's own settings locally in the browser: on/off toggles, sensitivity, per-intent preferences, a trusted-accounts allowlist, and locally-kept label corrections. None of this is transmitted off the device.
+```
+
+**Host permission - `http://localhost:8420/*` and `http://127.0.0.1:8420/*`**
+```
+The extension sends page text to the intentKeeper classification server running on the user's OWN computer (localhost) to be labeled. This is the only network destination the extension contacts. No external or remote servers are used.
+```
+
+**Content scripts - twitter.com, x.com, youtube.com, reddit.com**
+```
+The extension must read post/title/comment text on these sites to classify it, and modify the page to blur, tag, or hide flagged items. It runs only on these three platforms.
+```
+
+### Data usage disclosures (data safety form)
+
+Answer the checkboxes as follows:
+
+- Does this item collect or use user data? **Yes** (it reads page content) - but:
+  - "Personally identifiable information" - **No**
+  - "Web history" - **No**
+  - "User activity / analytics" - **No**
+  - Website content is read and sent **only to the user's own local machine**, not to the developer or any third party.
+- I do not sell or transfer user data to third parties: **certify true**
+- I do not use or transfer data for purposes unrelated to the item's single purpose: **certify true**
+- I do not use or transfer data to determine creditworthiness or for lending: **certify true**
+
+### Privacy policy URL  **[human - needs a public URL]**
+
+Point to the hosted `PRIVACY.md` in the repo, e.g.:
+```
+https://github.com/Olawoyin007/intentKeeper/blob/main/PRIVACY.md
+```
+
+---
+
+## Graphic assets  **[human - images required]**
+
+Chrome Web Store requires:
+
+- **Store icon**: 128x128 PNG - already in the repo at `extension/icons/icon128.png`.
+- **Screenshots**: at least 1 (up to 5), 1280x800 or 640x400 PNG/JPEG.
+  Suggested shots: (1) a tweet blurred with a "ragebait" tag, (2) the popup with
+  the per-intent toggles, (3) a YouTube thumbnail flagged as hype, (4) the
+  trusted-accounts allowlist. These need to be captured from a live browser -
+  an agent cannot produce them.
+- **Small promo tile** (optional): 440x280 PNG.
+
+## Reviewer notes  **[paste into "Notes for reviewers"]**
+
+```
+This extension requires a local classification server (open-source, shipped with the project) running on the reviewer's machine at http://localhost:8420. Without it, the extension intentionally does nothing - it has no remote server by design ("no data leaves the device" is the core promise).
+
+To test: follow the setup at https://github.com/Olawoyin007/intentKeeper (install Ollama + the intentKeeper Python server, start it), then browse Twitter/X, YouTube, or Reddit. Posts will be classified and blurred/tagged/hidden per the popup settings.
+
+No account, login, or payment is needed. No data is transmitted to the developer or any third party.
+```

--- a/store/SUBMISSION_CHECKLIST.md
+++ b/store/SUBMISSION_CHECKLIST.md
@@ -1,0 +1,68 @@
+# Chrome Web Store - Submission Checklist
+
+What an agent has prepared, and what only you can do. Work top to bottom.
+
+## What is ready (in this repo)
+
+- [x] Listing copy - name, summary, description, category, single-purpose
+      statement, permission justifications, data-safety answers, reviewer notes:
+      `store/CHROME_WEB_STORE.md`
+- [x] Privacy policy text: `PRIVACY.md`
+- [x] Store icon (128x128): `extension/icons/icon128.png`
+- [x] Manifest cleaned for review - the unused `activeTab` permission was
+      removed, so the listing only requests `storage` + the localhost host
+      permission (fewer permissions = smoother review + a cleaner privacy story).
+
+## Human tasks (you must do these)
+
+### 1. Developer account + fee
+- [ ] Create a Chrome Web Store developer account at
+      https://chrome.google.com/webstore/devconsole
+- [ ] Pay the **one-time $5 registration fee** (this is the "payment" in the
+      plan - it's Google's fee, not a paywall on intentKeeper).
+
+### 2. Build the package to upload
+- [ ] From the repo:
+      ```
+      cd extension
+      npm ci
+      npm test          # confirm green before packaging
+      npm run build     # emits dist/chrome (MV3) and dist/firefox
+      cd dist/chrome
+      zip -r ../../../intentkeeper-chrome-0.6.0.zip .
+      ```
+- [ ] The file to upload is `intentkeeper-chrome-0.6.0.zip` (the **contents** of
+      `dist/chrome`, zipped - `manifest.json` must be at the zip root).
+
+### 3. Screenshots (cannot be automated)
+- [ ] Capture 1-5 screenshots at **1280x800** (or 640x400). Suggested:
+      1. a tweet blurred with a "ragebait" tag
+      2. the popup with per-intent toggles + sensitivity slider
+      3. a YouTube thumbnail flagged as hype
+      4. the trusted-accounts allowlist
+- [ ] Optional: a 440x280 small promo tile.
+
+### 4. Host the privacy policy
+- [ ] The store asks for a **privacy policy URL**. Point it at the hosted file:
+      `https://github.com/Olawoyin007/intentKeeper/blob/main/PRIVACY.md`
+      (works once this branch is merged to `main`).
+
+### 5. Fill the dashboard and submit
+- [ ] Paste each field from `store/CHROME_WEB_STORE.md` into the matching box.
+- [ ] Paste the **reviewer notes** - they explain that a local server is
+      required, which is unusual and will otherwise confuse the reviewer.
+- [ ] Complete the data-safety form using the answers in the listing doc.
+- [ ] Upload the zip, upload screenshots, set the privacy policy URL.
+- [ ] Submit for review.
+
+## Notes
+
+- **Why the reviewer notes matter:** intentKeeper does nothing without the local
+  server running. A reviewer who just installs the extension and opens Twitter
+  will see no effect and may reject it. The notes tell them to start the server
+  first.
+- **Same kit works for Microsoft Edge Add-ons** (Chromium, MV3) - the zip and
+  most copy carry over; Edge has its own dashboard and a separate (free)
+  registration.
+- **Firefox / AMO** is a different submission (uses `dist/firefox`) and is
+  tracked separately under Phase 8.2.


### PR DESCRIPTION
## Summary
Prepares everything an agent can for the Chrome Web Store (and Edge Add-ons) submission - this is the "prepare for the store submission" half of the plan. The $5 fee, screenshots, and the actual submit stay human tasks.

Added:
- `store/CHROME_WEB_STORE.md` - ready-to-paste listing: product name, 132-char summary, category, detailed description, single-purpose statement, per-permission justifications, data-safety form answers, and reviewer notes (the reviewer notes matter: the extension does nothing without the user's local server running, which would otherwise read as broken).
- `PRIVACY.md` - privacy policy. Local-first: no data leaves the device, no analytics, no remote servers; the only network call is to the user's own `localhost:8420`.
- `store/SUBMISSION_CHECKLIST.md` - the human steps, top to bottom (dev account + $5 fee, build+zip commands, screenshots, privacy-policy URL, submit).

Also **removed the unused `activeTab` permission** from `extension/manifest.json`. It was declared but never called anywhere in the code; unused permissions are a CWS review risk and weaken the privacy story. The extension now requests only `storage` + the localhost host permission.

ROADMAP 8.1 updated (kit prepared; submit remains human).

## Testing
- `cd extension && npm run build` - emits `dist/chrome` + `dist/firefox`; `activeTab` absent from both manifests; both valid JSON
- `cd extension && npm test` - 81 pass
- `pytest tests/ -q` - 97 pass