### PR TITLE
feat: honest 'not analyzed' marker for media-dominant posts (#124, #136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,16 +29,27 @@ All notable changes to IntentKeeper are documented here.
   `qwen2.5:14b-instruct-q4_K_M` edges it at 97%. `README.md` recommended-models
   table updated to the fresh figures (was the 98-example 2026-06-14 set).
 
+### Added
+- `/health` now reports `vision: bool` - whether an `OLLAMA_VISION_MODEL` is
+  configured on the server. The extension uses this to decide how to handle
+  media-dominant posts (see below).
+
 ### Changed
-- Minimum-signal skip for media-dominant / low-text posts (issue #124). The
-  extension now measures a post's *readable* text - metadata brackets
-  (`[Author: X]`, `[r/news]`, `[Video tweet]`), URLs, and @handles stripped -
-  and skips classification when that falls below the length threshold, instead
-  of spending a classify call on content it cannot actually read. Fails open (no
-  treatment), matching the manifesto. Posts carrying media URLs are never
-  skipped here - the server's vision model may still read the image. The full
-  text (handles and all) is still what gets classified when a post is not
-  skipped. New `contentSignal()` helper with 7 Jest tests.
+- Honest handling of media-dominant / low-text posts (issues #124, #136). The
+  extension measures a post's *readable* text - metadata brackets
+  (`[Author: X]`, `[r/news]`, `[Video tweet]`), URLs, and @handles stripped
+  via the new `contentSignal()` helper. Three outcomes now, instead of a bad
+  guess from scraped metadata:
+  - Enough readable text: classified normally (full text still sent), whether
+    or not media is attached.
+  - Too little text but the post carries an image/video, and **no** vision
+    model is configured: a dim, non-judgemental "Media - not analyzed yet"
+    badge instead of a manipulation label. When a vision model is plugged in
+    (`OLLAMA_VISION_MODEL`), these posts flow through to be classified with
+    image context instead.
+  - Too little text and no media: silent skip (nothing to classify).
+  Fails open throughout, matching the manifesto - no fabricated verdicts.
+  `contentSignal()` covered by 7 Jest tests; `/health.vision` by 2 server tests.
 - Phase 7 (Statistics Dashboard) deferred pending manifesto reconciliation.
   The manifesto commits intentKeeper to "doesn't track or nudge" and its
   Living Clause forbids changes that add tracking; exposure counters sit in

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -431,6 +431,10 @@ Safari requires Apple developer account, Xcode, and wrapping the extension in a 
 **Goal**: Push classification accuracy with advanced techniques.
 
 ### 9.1 Multimedia Support
+- [x] Honest placeholder for media the tool cannot read yet (issues #124, #136):
+      media-dominant posts show a "not analyzed yet" badge instead of a guessed
+      label when no vision model is configured. `/health.vision` is the plug-in
+      seam - set `OLLAMA_VISION_MODEL` and those posts flow through vision.
 - [ ] Image analysis for memes (requires vision model)
 - [ ] Video thumbnail analysis
 - [ ] Audio/video content classification (transcription)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,13 +53,18 @@ Content Intercepted (tweet / post / comment)
     ▼
 ┌─────────────────────────────────────────────┐
 │  1. MINIMUM-SIGNAL CHECK                    │
-│     readable text (metadata/URL/@handle     │
-│      stripped) < 20 chars AND no media URLs │
-│      → mark "skipped" (media-dominant post) │
+│     readable text = contentSignal(text):    │
+│      metadata brackets/URLs/@handles removed│
+│     ≥ 20 chars → classify (text carries it, │
+│       whether or not media is attached)     │
+│     < 20 AND no media → mark "skipped"      │
+│     < 20 AND media, no vision model → mark  │
+│       "media-unanalyzed" ("not analyzed yet"│
+│       badge, no verdict fabricated)         │
+│     < 20 AND media, vision on → pass        │
+│       (server vision reads the image)       │
 │     empty string → leave unmarked          │
-│       (element still loading, retry next   │
-│        observer pass)                       │
-│     has media URLs → pass (vision may read) │
+│       (element still loading, retry next)   │
 └─────────────────────────────────────────────┘
     │ Pass
     ▼

--- a/extension/core/classifier.js
+++ b/extension/core/classifier.js
@@ -47,6 +47,11 @@ let pendingReprocess = false;
 let foundCount = 0;
 let classifiedCount = 0;
 
+// Whether the server has a vision model configured (reported by /health).
+// When false, media-dominant posts are marked "not analyzed yet" rather than
+// judged from scraped metadata. Flipped on once a vision model is plugged in.
+let visionAvailable = false;
+
 // Debug logger - only logs when debug._enabled is true
 const debug = {
   _enabled: false,
@@ -356,6 +361,25 @@ function applyTag(element, intent, confidence, content) {
 }
 
 /**
+ * Mark a media-dominant post as not yet analyzed. The post is mostly image or
+ * video with too little text to classify, and no vision model is configured to
+ * read the media - so intentKeeper makes no manipulation judgement and says so
+ * plainly, rather than guessing from scraped metadata. Honest placeholder until
+ * a vision model is plugged in (OLLAMA_VISION_MODEL). Respects the tag toggle:
+ * with tags off it just marks the item processed so it is not re-scanned.
+ */
+function applyNotAnalyzed(element) {
+  element.setAttribute(PROCESSED_ATTR, 'media-unanalyzed');
+  if (!settings.showTags) return;
+  const tag = document.createElement('div');
+  tag.className = 'intentkeeper-tag intentkeeper-tag--unanalyzed';
+  tag.textContent = 'Media - not analyzed yet';
+  tag.title = 'This post is mostly image or video. No vision model is configured, so it has not been judged.';
+  element.style.position = 'relative';
+  element.insertBefore(tag, element.firstChild);
+}
+
+/**
  * Blur the content area within an element, with a reveal button.
  *
  * Uses adapter.getContentElement() to find the sub-element to blur.
@@ -492,31 +516,42 @@ async function processItems(adapter) {
     for (const item of items) {
       const text = normalizeWhitespace(adapter.extractText(item));
       const mediaUrls = adapter.extractMediaUrls ? adapter.extractMediaUrls(item) : [];
-      // Minimum-signal skip: a media-dominant post scrapes down to mostly
-      // metadata/handles/URLs, leaving too little real text to classify. Skip it
-      // rather than waste a classify call on low-confidence noise (fail open - no
-      // treatment). Posts carrying media URLs are never skipped here: the server's
-      // vision model may read the image, so we let it decide.
-      if (mediaUrls.length === 0 && contentSignal(text).length < MIN_CONTENT_LENGTH) {
-        // Only permanently skip items with SOME text (genuinely thin content).
-        // Empty string means the element is still loading (lazy render) -
-        // leave it unmarked so the next observer pass can pick it up.
+      // A post scrapes down to mostly metadata/handles/URLs has too little real
+      // text to classify on words alone. What we do then depends on the media:
+      const hasSignal = contentSignal(text).length >= MIN_CONTENT_LENGTH;
+      const mediaOnly = !hasSignal && mediaUrls.length > 0;
+
+      if (!hasSignal && !mediaOnly) {
+        // Thin text and no media: genuinely nothing to classify. Silent skip.
+        // Empty string means the element is still loading (lazy render) - leave
+        // it unmarked so the next observer pass can pick it up.
         if (text.length > 0) {
           item.setAttribute(PROCESSED_ATTR, 'skipped');
         }
-      } else {
-        // Skip classification for allowlisted authors
-        if (adapter.extractAuthor) {
-          const author = adapter.extractAuthor(item);
-          if (author && allowlist.has(author)) {
-            item.setAttribute(PROCESSED_ATTR, 'allowed');
-            continue;
-          }
-        }
-        item.classList.add('intentkeeper-classifying');
-        foundCount++;
-        itemData.push({ item, text, mediaUrls });
+        continue;
       }
+
+      if (mediaOnly && !visionAvailable) {
+        // Image/video post with too little text, and no vision model configured
+        // to actually read the media. Don't fabricate a verdict from scraped
+        // alt-text/metadata - mark it honestly as "not analyzed yet". When a
+        // vision model is plugged in (visionAvailable), this branch is skipped
+        // and the post flows through to be classified with image context.
+        applyNotAnalyzed(item);
+        continue;
+      }
+
+      // Skip classification for allowlisted authors
+      if (adapter.extractAuthor) {
+        const author = adapter.extractAuthor(item);
+        if (author && allowlist.has(author)) {
+          item.setAttribute(PROCESSED_ATTR, 'allowed');
+          continue;
+        }
+      }
+      item.classList.add('intentkeeper-classifying');
+      foundCount++;
+      itemData.push({ item, text, mediaUrls });
     }
 
     for (let i = 0; i < itemData.length; i += MAX_CONCURRENT) {
@@ -643,7 +678,8 @@ window.IntentKeeperCore = {
         return;
       }
       connected = true;
-      debug.log(`API connected (model: ${health.model})`);
+      visionAvailable = !!health.vision;
+      debug.log(`API connected (model: ${health.model}, vision: ${visionAvailable})`);
     } catch (e) {
       debug.error('Cannot connect to background worker', e.message || e);
       createStatusBadge(adapter.platform, false);

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -225,6 +225,15 @@
   color: #808080;
 }
 
+/* Not a verdict: a media-dominant post no vision model has read yet. Dim and
+   italic so it reads as a status, not a manipulation label. */
+.intentkeeper-tag--unanalyzed {
+  background: rgba(128, 128, 128, 0.12);
+  color: #9aa0a6;
+  font-weight: 400;
+  font-style: italic;
+}
+
 .intentkeeper-tag-clickbait {
   background: rgba(255, 69, 0, 0.2);
   color: #ff4500;

--- a/server/api.py
+++ b/server/api.py
@@ -184,6 +184,7 @@ class HealthResponse(BaseModel):
     status: str
     ollama_connected: bool
     model: str
+    vision: bool = False
 
 
 class VersionResponse(BaseModel):
@@ -227,6 +228,7 @@ async def health_check():
         status="ok" if ollama_ok else "degraded",
         ollama_connected=ollama_ok,
         model=classifier.model if classifier else "none",
+        vision=bool(os.getenv("OLLAMA_VISION_MODEL", "").strip()),
     )
 
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -418,8 +418,11 @@ class TestAPIEndpoints:
         assert isinstance(data["debug"], bool)
 
     @pytest.mark.asyncio
-    async def test_health_endpoint(self, mock_classifier):
+    async def test_health_endpoint(self, mock_classifier, monkeypatch):
         """GET /health should return health status."""
+        # With no vision model configured, /health.vision is False and the
+        # extension marks media "not analyzed" instead of guessing.
+        monkeypatch.delenv("OLLAMA_VISION_MODEL", raising=False)
         with patch("server.api.classifier", mock_classifier):
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as ac:
@@ -429,6 +432,19 @@ class TestAPIEndpoints:
         data = response.json()
         assert data["status"] == "ok"
         assert data["ollama_connected"] is True
+        assert data["vision"] is False
+
+    @pytest.mark.asyncio
+    async def test_health_reports_vision_when_configured(self, mock_classifier, monkeypatch):
+        """/health.vision is True when a vision model is configured."""
+        monkeypatch.setenv("OLLAMA_VISION_MODEL", "moondream")
+        with patch("server.api.classifier", mock_classifier):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                response = await ac.get("/health")
+
+        assert response.status_code == 200
+        assert response.json()["vision"] is True
 
     @pytest.mark.asyncio
     async def test_classify_endpoint(self, mock_classifier):


### PR DESCRIPTION
## Summary

Adds the honest "Media - not analyzed yet" marker for media-dominant posts,
instead of silently skipping them or fabricating a verdict from thin scraped
metadata (alt text, aria-labels, thumbnails).

## Why this is a separate PR

PR #133 was meant to carry this, but only its first commit (the plain "skip"
behaviour) landed in main. The honest-marker commit was left on the branch and
never merged. This PR carries just that missing piece onto current main.

## Behaviour

- Enough readable text -> classify normally (media or not).
- Thin text + has media + no vision model -> dim "not analyzed yet" badge, no verdict.
- Thin text + no media -> silent skip.
- Server `/health` now reports `vision` (whether `OLLAMA_VISION_MODEL` is set),
  so a vision model can later be plugged in and these posts flow through to be
  classified with image context. Fails open throughout.

Closes #136. Completes the media handling for #124.

## Testing

- Jest: 88 passed.
- pytest (`test_classifier.py`): 62 passed, incl. new `vision`-flag health tests.
