### PR TITLE
fix(deps): patch js-yaml and brace-expansion high-severity advisories

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1634,9 +1634,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3392,9 +3392,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/extension/package.json
+++ b/extension/package.json
@@ -12,8 +12,8 @@
     "jest-environment-jsdom": "^30.3.0"
   },
   "overrides": {
-    "js-yaml": "^4.3.0",
-    "brace-expansion": "^5.0.8"
+    "js-yaml": "^4.3.1",
+    "brace-expansion": "^5.0.9"
   },
   "jest": {
     "testEnvironment": "jsdom",


### PR DESCRIPTION
## Summary

Clears two open high-severity advisories in the extension's dev-dependency tree (both pulled in transitively via jest, neither ships in the built extension):

- **js-yaml** 4.3.0 -> 4.3.1 - Dependabot alert #14, CVE-2026-59870 (quadratic CPU in `!!omap` resolution).
- **brace-expansion** 5.0.8 -> 5.0.9 - GHSA-rgw5-rvv9-x895, DoS via unbounded intermediate arrays (bypasses the CVE-2026-14257 mitigation). 5.0.8 was still within the vulnerable range `<5.0.9`.

Both packages already had `overrides` pins; the pins just predated the patched releases. This bumps the override floors and refreshes the lockfile. No source changes.

`npm audit` now reports 0 vulnerabilities.

## Testing

- `npm install` - lockfile resolves js-yaml 4.3.1 and brace-expansion 5.0.9
- `npm audit --audit-level=high` - found 0 vulnerabilities
- `npm run build` - dist/chrome and dist/firefox build clean
- `npm test` - 88 passed, 5 suites