### PR TITLE
release: v0.7.0 - Firefox, Store Kit & Honest Media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to IntentKeeper are documented here.
 
 ## [Unreleased]
 
+## v0.7.0 (2026-08-23) - Firefox, Store Kit & Honest Media
+
 ### Added
 - Chrome Web Store submission kit (Phase 8.1). `store/CHROME_WEB_STORE.md`
   (listing copy, single-purpose statement, permission justifications,
@@ -26,6 +28,9 @@ All notable changes to IntentKeeper are documented here.
   keeps the existing `onMessage` `return true`/`sendResponse` pattern, which is
   native on both engines. All 81 Jest tests pass unchanged. Manual Firefox
   Developer Edition smoke test and AMO submission remain (human tasks).
+- `/health` now reports `vision: bool` - whether an `OLLAMA_VISION_MODEL` is
+  configured on the server. The extension uses this to decide how to handle
+  media-dominant posts (see below).
 
 ### Documentation
 - `docs/model-benchmark.md`: added a 2026-07-13 full sweep (full 105-example
@@ -33,11 +38,6 @@ All notable changes to IntentKeeper are documented here.
   spot-check. Confirms `llama3.1:8b` as the sweet spot (96% at 8 GB);
   `qwen2.5:14b-instruct-q4_K_M` edges it at 97%. `README.md` recommended-models
   table updated to the fresh figures (was the 98-example 2026-06-14 set).
-
-### Added
-- `/health` now reports `vision: bool` - whether an `OLLAMA_VISION_MODEL` is
-  configured on the server. The extension uses this to decide how to handle
-  media-dominant posts (see below).
 
 ### Changed
 - Honest handling of media-dominant / low-text posts (issues #124, #136). The
@@ -83,7 +83,7 @@ All notable changes to IntentKeeper are documented here.
 ### Security
 - Removed the dead `chrome-extension://*` entry from the CORS `allow_origins` list in `server/api.py`. Starlette matches `allow_origins` by exact string, so the literal never matched a real extension origin - it was misleading config, not an active allowance. No behaviour change: the extension reaches the server via MV3 `host_permissions`, which bypass page CORS, and CORS continues to fail closed for extension origins. Added a comment explaining this and flipped the test that had asserted the dead entry was present (closes #113)
 - Fixed the compose-file shadowing left by #95: `docker-compose.yml` (server-only, host Ollama, hardened defaults) was silently dead because Compose prefers `docker-compose.yaml`, so the documented `docker compose up` ran the old bundled stack with the API published on all interfaces (`8420:8420`). The canonical `docker-compose.yaml` now binds `127.0.0.1` by default (`APP_BIND`/`APP_PORT` to override), passes `PUID`/`PGID` through to the #95 entrypoint, and bind-mounts `./data`; the host-Ollama variant is renamed to `docker-compose.host-ollama.yml` and documented in the README (`docker compose -f docker-compose.host-ollama.yml up`)
-- Cleared two high-severity npm advisories in the extension's dev toolchain (transitive under `jest`): `js-yaml` (GHSA quadratic-CPU DoS via YAML merge-key chains, `<4.3.0`) and `brace-expansion` (GHSA-mh99-v99m-4gvg unbounded-expansion OOM, patched only in `5.0.8`). Bumped the existing `js-yaml` override to `^4.3.0` and added a `brace-expansion: ^5.0.8` override; `npm audit` is now clean and all 81 jest tests pass. Dev-only: neither package ships in the extension users install (Dependabot #11, #12)
+- Cleared the high-severity npm advisories in the extension's dev toolchain (all transitive under `jest`, dev-only - neither package ships in the extension users install). Final override floors: `js-yaml` -> `4.3.1` (CVE-2026-59870, quadratic CPU in `!!omap` resolution; Dependabot #14, PR #138) and `brace-expansion` -> `5.0.9` (GHSA-rgw5-rvv9-x895, DoS via unbounded intermediate arrays that bypassed the CVE-2026-14257 mitigation; PR #138). `npm audit` reports 0 vulnerabilities and all 88 jest tests pass (Dependabot #11, #12)
 
 ## v0.6.0 (2026-07-02) - Long-Form Posts & Eval Depth
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <!-- Project -->
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
-  <img src="https://img.shields.io/badge/version-0.6.0-green.svg" alt="Version: 0.6.0">
+  <img src="https://img.shields.io/badge/version-0.7.0-green.svg" alt="Version: 0.7.0">
   <img src="https://img.shields.io/badge/accuracy-96%25-brightgreen.svg" alt="Accuracy: 96%">
   <a href="https://github.com/Olawoyin007/intentKeeper/actions/workflows/ci.yml"><img src="https://github.com/Olawoyin007/intentKeeper/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
 </p>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "intentKeeper",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A digital bodyguard for your mind - filters content by intent",
   "permissions": [
     "storage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "intentkeeper"
-version = "0.6.0"
+version = "0.7.0"
 description = "A digital bodyguard for your mind - local content intent classification"
 readme = "README.md"
 license = {text = "MIT"}

--- a/server/api.py
+++ b/server/api.py
@@ -84,7 +84,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="IntentKeeper",
     description="Local content intent classification API",
-    version="0.6.0",
+    version="0.7.0",
     lifespan=lifespan,
 )
 

--- a/store/SUBMISSION_CHECKLIST.md
+++ b/store/SUBMISSION_CHECKLIST.md
@@ -29,9 +29,9 @@ What an agent has prepared, and what only you can do. Work top to bottom.
       npm test          # confirm green before packaging
       npm run build     # emits dist/chrome (MV3) and dist/firefox
       cd dist/chrome
-      zip -r ../../../intentkeeper-chrome-0.6.0.zip .
+      zip -r ../../../intentkeeper-chrome-0.7.0.zip .
       ```
-- [ ] The file to upload is `intentkeeper-chrome-0.6.0.zip` (the **contents** of
+- [ ] The file to upload is `intentkeeper-chrome-0.7.0.zip` (the **contents** of
       `dist/chrome`, zipped - `manifest.json` must be at the zip root).
 
 ### 3. Screenshots (cannot be automated)

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -398,7 +398,7 @@ class TestAPIEndpoints:
         assert response.status_code == 200
         data = response.json()
         assert "version" in data
-        assert data["version"] == "0.6.0"
+        assert data["version"] == "0.7.0"
 
     @pytest.mark.asyncio
     async def test_config_endpoint(self, mock_classifier):


### PR DESCRIPTION
## Summary

Cuts the **v0.7.0** release. Bumps `0.6.0 -> 0.7.0` across every version-bearing file (pyproject, extension manifest, `server/api.py`, README badge, the version-endpoint test, and the store checklist zip name), retitles the changelog `[Unreleased]` section to `v0.7.0`, folds a duplicate `### Added` block into one, and refreshes the security bullet to the final shipped override floors (`js-yaml` 4.3.1, `brace-expansion` 5.0.9 - PR #138).

What ships in this cycle:
- **Firefox support** (Phase 8.2) - one source manifest, per-browser build (`dist/chrome` MV3 + `dist/firefox` event page).
- **Chrome Web Store submission kit** (Phase 8.1) - listing copy, privacy policy, submission checklist.
- **Honest media-dominant post handling** (issues #124, #136) - readable-text signal, "not analyzed yet" badge instead of a bad guess, fails open.
- **Server CLI flags** `--host` / `--port` / `--version` (issue #117).
- Dev-toolchain security advisories cleared (js-yaml, brace-expansion).

No product source changes in this PR beyond the version strings - the features above already merged during the cycle; this PR just stamps the release.

## Testing

- `python scripts/check_version.py` - all version references consistent at 0.7.0
- `pytest` - 98 passed, 86% coverage
- `npm test` (extension) - 88 passed, 5 suites
- `npm run build` - dist/chrome and dist/firefox build clean