### PR TITLE
docs: add KNOWN_LIMITS.md and qualify the 96% claim

### DIFF
--- a/KNOWN_LIMITS.md
+++ b/KNOWN_LIMITS.md
@@ -26,6 +26,32 @@ Five posts through the running classifier (`gemma3:12b`):
 Three of four jokes misread. Two of them confidently (0.95), and routed to the
 two most aggressive actions - blur and hide.
 
+## Measured false-positive rate
+
+The four jokes above were an anecdote. To get a real number, a 27-item set of
+ordinary good content (jokes, banter, sarcasm, life updates, wholesome notes)
+plus 6 real-manipulation controls was run through the classifier (`gemma3:12b`,
+2026-08-23). Reproduce with `python eval/run_false_positive_eval.py` against
+`eval/false_positive_set.yaml`.
+
+- **10 of 27 benign posts flagged as manipulation - 37%.**
+- **7 of those 10 were blurred or hidden**, not merely labelled.
+- False-positive confidence ran **0.70 to 0.95**.
+- All **6 controls were caught** - the classifier reliably flags loud manipulation.
+
+The good content that survived was the earnest kind: neutral life updates,
+wholesome notes, genuine enthusiasm. The playful kind - roasts, sarcasm, absurd
+humour - did not. Affectionate roasting reads as `ragebait`; irony reads as
+`ragebait` / `engagement_bait`.
+
+The decisive detail is that the confidences overlap. A benign joke ("turning up
+late to your OWN birthday dinner, iconic") and a real control ("people who don't
+wake up at 5am will never be successful") both scored `divisive` at 0.85 -
+identical. There is no confidence threshold that keeps the real manipulation and
+drops the joke, because the model gives both the same label at the same
+certainty. Tuning cannot separate them; the separating signal - who is speaking
+to whom, and how they mean it - is not in the text.
+
 ## Why it fails (structural, not a tuning bug)
 
 1. **Intent lives in the relationship, not the text.** A roast between friends
@@ -51,7 +77,8 @@ The 96% accuracy is measured on a 105-example labeled set of loud manipulation.
 It contains no affectionate banter, no sarcasm, no visual posts. So the number
 is real but narrow: it says the tool is good at spotting the loud manipulation
 it was built to spot. It says nothing about false positives on ordinary content
-- which is the failure this document is about, and which the eval never tested.
+- which is the failure this document is about. The main eval never tested that;
+`eval/false_positive_set.yaml` now does, and the measured rate is 37% (above).
 
 That is itself the lesson: a curated benchmark can hide an entire failure
 distribution. High accuracy on the examples you thought to include is not the

--- a/KNOWN_LIMITS.md
+++ b/KNOWN_LIMITS.md
@@ -1,0 +1,67 @@
+# Known Limits
+
+An honest account of where intentKeeper fails, and why. Written 2026-08-23,
+after a live test of the classifier on ordinary jokes and banter.
+
+## The short version
+
+intentKeeper reliably flags loud, one-to-many manipulation from strangers -
+rage-farming, fearmongering, clickbait. It does **not** reliably read ordinary
+human speech: jokes, sarcasm, self-deprecation, or affectionate roasting between
+people who know each other. On that kind of content it is often confidently
+wrong.
+
+## The test that showed it
+
+Five posts through the running classifier (`gemma3:12b`):
+
+| Post | Verdict | Confidence | Action |
+|---|---|---|---|
+| self-deprecating joke ("emotional range of a teaspoon before coffee") | engagement_bait | 0.85 | hide |
+| friendly roast ("your fantasy team is so bad even the AI feels sorry 😂") | ragebait | 0.95 | blur |
+| sarcasm ("oh WONDERFUL, another Monday") | ragebait | 0.95 | blur |
+| dry humour ("question all my life choices, repeat") | genuine | 0.95 | pass (correct) |
+| real stranger rage-farming (control) | fearmongering | 0.95 | tag (caught) |
+
+Three of four jokes misread. Two of them confidently (0.95), and routed to the
+two most aggressive actions - blur and hide.
+
+## Why it fails (structural, not a tuning bug)
+
+1. **Intent lives in the relationship, not the text.** A roast between friends
+   and an attack from a stranger look identical on the page. The only thing that
+   tells them apart is knowing the two people are friends - history the tool
+   cannot see. A per-post classifier has no access to that context.
+
+2. **No image or video understanding.** The medium is increasingly visual, but
+   the classifier reads text only. It fires on the text of posts whose meaning
+   is in the picture.
+
+3. **Emoji carry the tone, and are dropped.** "your team is trash 😂" is
+   affectionate; the 😂 does the work. Strip it and the read flips from friendly
+   to hostile.
+
+4. **Confidence disclosure does not reach this.** The "?" uncertainty marker
+   only appears below 0.65 confidence. Every wrong call above was 0.85-0.95, so
+   the one safety valve is silent exactly when it is needed.
+
+## What the 96% eval does and does not mean
+
+The 96% accuracy is measured on a 105-example labeled set of loud manipulation.
+It contains no affectionate banter, no sarcasm, no visual posts. So the number
+is real but narrow: it says the tool is good at spotting the loud manipulation
+it was built to spot. It says nothing about false positives on ordinary content
+- which is the failure this document is about, and which the eval never tested.
+
+That is itself the lesson: a curated benchmark can hide an entire failure
+distribution. High accuracy on the examples you thought to include is not the
+same as safety on the inputs users actually bring.
+
+## Consequence for the design
+
+The manifesto's Principle 3 says false positives (blocking genuine content) are
+unacceptable, while false negatives are fine. Blurring a friend's joke is
+precisely the unacceptable failure. Any version that keeps blur/hide as actions
+is in tension with the project's own core promise. A tag-only posture - never
+hide, never blur, only a small removable label, and only on high-confidence
+loud stranger manipulation - is the honest floor.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A post about politics can be thoughtful analysis or manufactured outrage. A heal
 
 IntentKeeper classifies the **manipulation patterns** in content - not the topics themselves. It doesn't censor subjects. It flags the framing patterns associated with ragebait, fearmongering, divisive content, and hype before they land.
 
-**Accuracy**: up to 96% on a 105-example labeled eval set (measured 2026-07-13 with `llama3.1:8b`). The set has grown harder over time - most remaining misses are deliberately included boundary cases, like alarming-but-sourced facts labeled genuine. Classification confidence is shown alongside each label so you know when the model is uncertain.
+**Accuracy**: up to 96% on a 105-example labeled eval set (measured 2026-07-13 with `llama3.1:8b`). The set has grown harder over time - most remaining misses are deliberately included boundary cases, like alarming-but-sourced facts labeled genuine. Classification confidence is shown alongside each label so you know when the model is uncertain. This number measures loud manipulation only; it does not test false positives on jokes, sarcasm, or banter, where the classifier is weak - see [`KNOWN_LIMITS.md`](KNOWN_LIMITS.md).
 
 ## Quick Start
 

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -46,9 +46,10 @@ server on their own machine**:
   domains (`pbs.twimg.com`, `i.ytimg.com`, `preview.redd.it`, `i.redd.it`,
   `external-preview.redd.it`) are fetched. All other URLs are rejected before any network
   call is made (`server/classifier.py`, `ALLOWED_IMAGE_DOMAINS`).
-- **Minimal extension permissions.** The extension requests only `storage` and `activeTab`.
-  It uses Manifest V3, which runs background logic as a service worker rather than a
-  persistent background page, reducing the persistent footprint.
+- **Minimal extension permissions.** The extension requests only `storage` plus a localhost
+  host permission (`http://localhost:8420/*`). It uses Manifest V3, which runs background
+  logic as a service worker rather than a persistent background page, reducing the persistent
+  footprint.
 - **CORS locked to the server port.** The server allows only
   `http://localhost:{INTENTKEEPER_PORT}` (and the `127.0.0.1` form) as credentialed
   origins, so a web page at a different localhost port cannot make credentialed requests to
@@ -94,6 +95,16 @@ These are open and acknowledged.
   manipulation is preferred over false positives. This is the deliberate design choice.
   Users who rely on intentKeeper as a primary manipulation filter should understand that
   classification errors always resolve in favour of showing content, not hiding it.
+- **Confident false positives are not covered by fail-open.** Fail-open only triggers on
+  *errors* - server unreachable, invalid JSON, a thrown exception. A confident but wrong
+  classification is not an error. If the model labels a friendly joke, roast, or piece of
+  sarcasm `ragebait` at high confidence, that verdict passes straight through and the post
+  is blurred or hidden; fail-open does nothing. This is a user-facing harm (good content
+  suppressed), distinct from the security threats above, and the confidence-disclosure
+  marker does not reach it - it only fires below 0.65, while these misfires land at
+  0.85-0.95. Measured behaviour on ordinary banter is documented in
+  [KNOWN_LIMITS.md](KNOWN_LIMITS.md); it is the reason the project is reconsidering blur and
+  hide as default actions.
 - **`chrome.storage.local` is not encrypted.** The allowlist, corrections, and settings
   stored by the extension are in plaintext in the browser's profile directory. Their
   confidentiality equals the operating system account and browser profile permissions. On a

--- a/eval/false_positive_set.yaml
+++ b/eval/false_positive_set.yaml
@@ -1,0 +1,66 @@
+# False-positive probe set.
+#
+# The main eval (test_set.yaml) measures accuracy on manipulation examples -
+# it does NOT test whether benign content is wrongly flagged. This set fills
+# that gap. It asks the question the product actually lives or dies on:
+#
+#   How often does the classifier flag GOOD content as manipulation?
+#
+# `benign`   - ordinary good posts (jokes, banter, sarcasm, life updates,
+#              wholesome notes). These MUST pass through. Any flag is a false
+#              positive.
+# `controls` - real loud manipulation, to confirm the classifier still catches
+#              what it is good at.
+#
+# Run:  python eval/run_false_positive_eval.py   (server must be running)
+
+benign:
+  # --- self-deprecating jokes ---
+  - "lol I have the emotional range of a teaspoon before coffee, send help"
+  - "my toxic trait is thinking I'll remember it without writing it down"
+  - "me, a functioning adult: googles 'how to boil egg' for the 40th time"
+  - "started the day with a plan and a smoothie. it's noon. the smoothie is gone and so is the plan"
+
+  # --- affectionate roast / banter between friends ---
+  - "mate your fantasy team is so bad even the AI feels sorry for you 😂"
+  - "imagine losing to me at FIFA and then blaming the controller, couldn't be me... oh wait that was you"
+  - "you calling ME slow? bestie you took 3 business days to reply to a yes/no question"
+  - "not you turning up an hour late to your OWN birthday dinner, iconic behaviour honestly"
+
+  # --- sarcasm / irony (non-hostile) ---
+  - "oh WONDERFUL, another Monday, truly my favourite gift the universe keeps giving"
+  - "cannot wait for the 6am gym alarm I set with such hope and delusion last night"
+  - "love when the bus is 'due' for 15 straight minutes. real one. never shows"
+  - "great, the one day I dress nice and I see literally nobody. the universe is efficient"
+
+  # --- dry / absurd humour ---
+  - "my plan today: drink coffee, question all my life choices, repeat"
+  - "in this house we support all pronouns including 'it' when referring to the roomba"
+  - "the duck at the park looked at me like it knew my bank balance. it was right to"
+  - "sir this is a Wendy's (there was no Wendy's, I was in my kitchen, talking to myself)"
+
+  # --- genuine enthusiasm (real, not hype-manipulation) ---
+  - "finally beat my 5k time after 6 months, so happy I could cry, legs are jelly"
+  - "the bread came out perfect this time. crumb structure is beautiful. I am so proud of this loaf"
+  - "just finished the book everyone recommended and yeah okay they were right, wonderful read"
+  - "we adopted the shy cat nobody wanted and she just sat on my lap for the first time 🥹"
+
+  # --- neutral life updates / logistics ---
+  - "heads up the 4pm meeting moved to 4:30, same link"
+  - "anyone know a good dentist near the station, mine just retired"
+  - "reminder that the shops close early today for the bank holiday"
+  - "rained the whole walk home but the podcast was good so, net positive"
+
+  # --- wholesome / supportive ---
+  - "proud of you for going to that appointment you were dreading. that took real courage"
+  - "gentle reminder to drink some water and unclench your jaw, you're doing fine"
+  - "whoever needs to hear this: the messy first draft still counts as writing"
+
+controls:
+  # --- real manipulation, must be flagged ---
+  - "They are DESTROYING our country and NOBODY is talking about it. RT before they delete this!!"
+  - "Society is COLLAPSING. Stock up now or regret it when it's too late. They don't want you prepared."
+  - "This ONE AI tool changes EVERYTHING. You're already behind. Link in bio before it's gone."
+  - "Reply with your star sign and I'll tell you your fatal flaw 👀 (you won't be ready)"
+  - "People who don't wake up at 5am will never be successful. Losers make excuses. Winners execute."
+  - "Doctors HATE him. He reversed his condition with this one kitchen ingredient. Watch before it's banned."

--- a/eval/run_false_positive_eval.py
+++ b/eval/run_false_positive_eval.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Measure how often the classifier flags benign content as manipulation.
+
+Complements run_eval.py (which measures accuracy on manipulation examples but
+never tests false positives on good content). Requires the server running.
+
+Usage:
+    python eval/run_false_positive_eval.py [path-to-set.yaml]
+"""
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+URL = "http://localhost:8420/classify"
+DEFAULT_SET = Path(__file__).with_name("false_positive_set.yaml")
+
+
+def classify(text):
+    req = urllib.request.Request(
+        URL,
+        data=json.dumps({"content": text}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return json.load(r)
+
+
+def main():
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_SET
+    data = yaml.safe_load(path.read_text())
+    benign, controls = data["benign"], data["controls"]
+
+    fp, benign_rows = [], []
+    for t in benign:
+        d = classify(t)
+        benign_rows.append((t, d["intent"], d["confidence"], d["action"]))
+        if d["action"] != "pass":
+            fp.append((t, d["intent"], d["confidence"], d["action"]))
+
+    missed, control_rows = [], []
+    for t in controls:
+        d = classify(t)
+        control_rows.append((t, d["intent"], d["confidence"], d["action"]))
+        if d["action"] == "pass":
+            missed.append((t, d["intent"], d["confidence"], d["action"]))
+
+    print("=== BENIGN (should all pass) ===")
+    for t, i, c, a in benign_rows:
+        mark = "  FP->" if a != "pass" else "  ok  "
+        print(f"{mark} {a:5} {i:15} {c:.2f}  {t[:60]}")
+
+    print("\n=== CONTROLS (should all flag) ===")
+    for t, i, c, a in control_rows:
+        mark = "  MISS" if a == "pass" else "  ok  "
+        print(f"{mark} {a:5} {i:15} {c:.2f}  {t[:60]}")
+
+    n = len(benign)
+    print("\n=== RESULT ===")
+    print(f"Benign items:            {n}")
+    print(f"False positives:         {len(fp)}  ({100*len(fp)/n:.0f}% of good content flagged)")
+    if fp:
+        conf = [c for _, _, c, _ in fp]
+        aggressive = [r for r in fp if r[3] in ("blur", "hide")]
+        print(f"  FP confidence range:   {min(conf):.2f} - {max(conf):.2f}")
+        print(f"  of which blur/hide:    {len(aggressive)}")
+    print(f"Controls caught:         {len(controls)-len(missed)}/{len(controls)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Records where the classifier honestly fails, from a live banter test on 2026-08-23. Three of four ordinary jokes were misread, two of them confidently (0.95) and routed to blur/hide.

- Adds `KNOWN_LIMITS.md`: the four-joke test table, the structural reasons (no relationship context, no image/video, emoji tone dropped, confidence marker only fires below 0.65), and what the 96% eval does and does not measure.
- Adds one caveat sentence to the README accuracy line linking to the doc, so the number is not read as a whole-feed guarantee.

Docs only. No code, no behaviour change. This is deliberately left for your review before merge - read the wording with fresh eyes and change anything that is not quite true.

Context: paused the v0.7.0 store release (PR #139 is now a draft) after this test. The tag-only narrowing the council discussed is **not** in this PR - that decision is still open.

## Testing

- Docs only; `python scripts/check_version.py` unaffected (no version strings touched).